### PR TITLE
Changes related to bzr->git conversion of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ libdrizzle/.dirstamp
 libdrizzle/.libs/
 libdrizzle/*.la
 libdrizzle/*.lo
+libdrizzle/*.o
 libdrizzle-*/version.h
 m4/libtool.m4
 m4/ltoptions.m4
@@ -41,3 +42,4 @@ docs/changes/
 docs/latex/
 libdrizzle-config
 test-suite.log
+


### PR DESCRIPTION
Changes apply after conversion of repo from `bazaar` to `git`
see https://design.canonical.com/2015/01/converting-projects-between-git-and-bazaar/ for more information
- The revision history has been retained with original authors/contributors linked to their github account where available
- The bzr ignore file, `.bzrignore` was renamed to `.gitignore` 
- Additional exclude `libdrizzle/*.o` has been added to `.gitignore` 
