### PR TITLE
Add callback function for poll events to client api

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,21 @@
+Dependencies
+============
+
+Dependency | Version
+-----------|---------
+gcc        | >=4.8.x
+automake   | >=v1.12
+CLooG      | >=v0.18.x
+
+
+New Features
+============
+
+* `libdrizzle-5.1/libdrizzle.h`
+
+  Added support for custom callback function, to allow clients to be notified
+  about file descriptor events. The new feature is available in the client API
+  through the function `drizzle_set_event_watch_fn`
+
+  Please refer to `docs/api/connection.rst` for documentation on
+  `drizzle_set_event_watch_fn`

--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -71,6 +71,15 @@ Functions
    :param function: The function to use in the format of :c:func:`drizzle_log_fn`
    :param context: A pointer to data to pass to the log function
 
+.. c:function:: void drizzle_set_event_watch_fn(drizzle_st *drizzle, drizzle_event_watch_fn *function, void *context)
+
+   Set a custom I/O event watcher function for a drizzle structure
+
+   :param drizzle: Drizzle structure previously initialized with
+    :c:func:`drizzle_create` or :c:func:`drizzle_clone`
+   :param function: Function to call when there is an I/O event, in the form of :c:func:`drizzle_event_watch_fn`
+   :param context: Argument to pass into the callback function.
+
 .. c:function:: const char* drizzle_error(const drizzle_st *con)
 
    Get the last error from a connection
@@ -348,3 +357,15 @@ Libdrizzle Redux library.
    :param verbose: The verbosity level of the message
    :param context: A pointer to data set in :c:func:`drizzle_set_log_fn`
 
+.. c:function:: drizzle_return_t drizzle_event_watch_fn(drizzle_st *con, short events, void *context)
+
+   The format of a function to register or deregister interest in file descriptor
+   events
+
+   :param con: Connection that has changed the events it is interested in.
+    Use drizzle_fd() to get the file descriptor.
+   :param events: A bit mask of POLLIN | POLLOUT, specifying if the
+    connection is waiting for read or write events.
+   :param context: Application context pointer registered with
+    :c:func:`drizzle_set_event_watch_fn`
+   :returns: DRIZZLE_RETURN_OK if successful.

--- a/libdrizzle-5.1/drizzle.h
+++ b/libdrizzle-5.1/drizzle.h
@@ -164,6 +164,29 @@ void drizzle_set_verbose(drizzle_st *con, drizzle_verbose_t verbose);
 DRIZZLE_API
 void drizzle_set_log_fn(drizzle_st *con, drizzle_log_fn *function,
                         void *context);
+
+
+/**
+ * Set a custom I/O event watcher function for a drizzle structure. Used to
+ * integrate libdrizzle with a custom event loop. The callback will be invoked
+ * to register or deregister interest in events for a connection. When the
+ * events are triggered, drizzle_con_set_revents() should be called to
+ * indicate which events are ready. The event loop should stop waiting for
+ * these events, as libdrizzle will call the callback again if it is still
+ * interested. To resume processing, the libdrizzle function that returned
+ * DRIZZLE_RETURN_IO_WAIT should be called again. See drizzle_event_watch_fn().
+ *
+ * @param[in] drizzle Drizzle structure previously initialized with
+ *  drizzle_create() or drizzle_clone().
+ * @param[in] function Function to call when there is an I/O event.
+ * @param[in] context Argument to pass into the callback function.
+ */
+DRIZZLE_API
+void drizzle_set_event_watch_fn(drizzle_st *drizzle,
+                                drizzle_event_watch_fn *function,
+                                void *context);
+
+
 /**
  * Wait for I/O on connections.
  *

--- a/libdrizzle/drizzle.cc
+++ b/libdrizzle/drizzle.cc
@@ -184,6 +184,14 @@ void drizzle_set_log_fn(drizzle_st *con, drizzle_log_fn *function, void *context
   con->log_context= context;
 }
 
+void drizzle_set_event_watch_fn(drizzle_st *drizzle,
+                                drizzle_event_watch_fn *function,
+                                void *context)
+{
+  drizzle->event_watch_fn= function;
+  drizzle->event_watch_context= context;
+}
+
 drizzle_st *drizzle_clone(drizzle_st *drizzle, const drizzle_st *from)
 {
   drizzle= new (std::nothrow) drizzle_st;

--- a/libdrizzle/structs.h
+++ b/libdrizzle/structs.h
@@ -219,6 +219,8 @@ struct drizzle_st
   unsigned char *command_data;
   void *context;
   drizzle_context_free_fn *context_free_fn;
+  void *event_watch_context; /* context for custom callback function  */
+  drizzle_event_watch_fn *event_watch_fn; /* custom call back function */
   drizzle_result_st *result;
   drizzle_result_st *result_list;
   unsigned char *scramble;
@@ -287,6 +289,8 @@ public:
     command_data(NULL),
     context(NULL),
     context_free_fn(NULL),
+    event_watch_context(NULL),
+    event_watch_fn(NULL),
     result(NULL),
     result_list(NULL),
     scramble(NULL),


### PR DESCRIPTION
This PR addresses the issue raised, https://answers.launchpad.net/libdrizzle/+question/233212, 
in which the removal of `event_watch_fn` meant that a client could no longer 
suscribe to and get notified about poll events 
