### PR TITLE
Add deb packaging support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ include m4/include.am
 include libdrizzle/include.am
 include libdrizzle-5.1/include.am
 include rpm/include.am
+include deb/include.am
 include docs/include.am
 
 EXTRA_DIST+= AUTHORS
@@ -69,5 +70,6 @@ maintainer-clean-local:
 	find . -type f -name '*~' -exec rm -f '{}' \;
 	-rm -f @PACKAGE@-*.tar.gz
 	-rm -f @PACKAGE@-*.rpm
+	-rm -f @PACKAGE@-*.deb
 
 dist_bin_SCRIPTS+= @GENERIC_CONFIG@ 

--- a/deb/build
+++ b/deb/build
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+cd `dirname $0`
+
+genchangelog()
+{
+        echo "$1 ($2) `lsb_release -sc`; urgency=low"
+        echo
+	prevtag=$(git describe --abbrev=0 HEAD^)
+        git log --date=short --format="  * %s (%h, %cd)" "$prevtag"..HEAD |
+                fold --spaces --width 76 | sed 's/^\([^ ]\+\)/    \1/'
+        echo
+        echo " -- $3  `LANG=C date -R`"
+}
+
+pkgversion=$(git describe --dirty | cut -c2- |
+		sed 's/-\([0-9]\+\)-\(g[0-9a-f]\+\)/+\1~\2/' |
+		sed 's/\(~g[0-9a-f]\+\)-dirty$/-dirty\1/' |
+		sed 's/-dirty/~dirty.'`date +%Y%m%d%H%M%S`'/'
+	)-$(lsb_release -cs)
+
+pkgmaint=$(echo "`git config user.name` <`git config user.email`>")
+
+changelog=`mktemp`
+trap "rm -f '$changelog'; exit 1" INT TERM QUIT
+
+pkgname=libdrizzle-redux
+genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
+fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
+	--architecture all \
+	--maintainer "$pkgmaint" \
+	--description "Simplified API to MySQL databases" \
+	--url 'https://github.com/sociomantic/libdrizzle-redux' \
+	--vendor 'Sociomantic Labs GmbH' \
+	--license 'Simplified BSD License' \
+	--category shared-lib \
+	--depends python2.7 \
+	--depends "git (>=1.7.7)" \
+	--deb-changelog "$changelog" \
+	install/usr
+

--- a/deb/include.am
+++ b/deb/include.am
@@ -1,0 +1,33 @@
+# vim:ft=automake
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+# 
+# Makefile for building deb package 
+
+
+.PHONY: deb
+deb: 
+	$(MAKE) DESTDIR=${abs_builddir}/deb/install install 
+	deb/build
+
+.PHONY: install-deb
+install-deb:
+	@echo "This target is empty at the moment." 
+	@echo "Should be something like:" 
+	@echo "    sudo dpkg -i libdrizzle-redux.[version].d"
+
+.PHONY: release-deb
+release-deb:
+	@read -p "Enter version (previous: $$(git describe --abbrev=0)): " version; \
+	test -z $$version && exit 1; \
+	msg=`echo $$version | sed 's/v/Version /;s/-rc/ Release Candidate /'`; \
+	echo ; \
+	echo Changelog: ; \
+	git log --format='* %s (%h)' `git describe --abbrev=0 HEAD^`..HEAD; \
+	echo ; \
+	set -x; \
+	git tag -a -m "$$msg" $$version
+
+clean-deb:
+	-rm -rf deb/*.deb deb/install 
+


### PR DESCRIPTION
Makefile now offers a target for **deb packaging**
The `deb` package is built using `fpm`:

```
https://github.com/jordansissel/fpm
```

Added `automake` include file for `deb`

Added script file, `deb/build` to build package using `fpm`

Add `/deb/include.am` to top level `Makefile.am`
