### PR TITLE
Fix install path for deb packaging

### DIFF
--- a/deb/build
+++ b/deb/build
@@ -38,5 +38,5 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 	--depends python2.7 \
 	--depends "git (>=1.7.7)" \
 	--deb-changelog "$changelog" \
-	install/usr
-
+	--deb-no-default-config-files \
+	install/=/

--- a/deb/build
+++ b/deb/build
@@ -35,8 +35,9 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 	--vendor 'Sociomantic Labs GmbH' \
 	--license 'Simplified BSD License' \
 	--category shared-lib \
-	--depends python2.7 \
-	--depends "git (>=1.7.7)" \
+	--depends autoconf \
+	--depends zlib1g-dev \
+	--depends libtool \
 	--deb-changelog "$changelog" \
 	--deb-no-default-config-files \
 	install/=/

--- a/deb/include.am
+++ b/deb/include.am
@@ -4,19 +4,18 @@
 # 
 # Makefile for building deb package 
 
+.PHONY: clean-deb deb install-deb release-deb
 
-.PHONY: deb
-deb: 
+deb: clean-deb
+	./configure --prefix=/usr
 	$(MAKE) DESTDIR=${abs_builddir}/deb/install install 
-	deb/build
+	deb/build deb
 
-.PHONY: install-deb
 install-deb:
 	@echo "This target is empty at the moment." 
 	@echo "Should be something like:" 
 	@echo "    sudo dpkg -i libdrizzle-redux.[version].d"
 
-.PHONY: release-deb
 release-deb:
 	@read -p "Enter version (previous: $$(git describe --abbrev=0)): " version; \
 	test -z $$version && exit 1; \
@@ -29,5 +28,4 @@ release-deb:
 	git tag -a -m "$$msg" $$version
 
 clean-deb:
-	-rm -rf deb/*.deb deb/install 
-
+	-rm -rf deb/*.deb deb/install


### PR DESCRIPTION
When running `dpkg -i` on the generated deb package, the libraries are installed 
to `/install/usr/local/lib`. 
Install path should be `/usr/local/lib`
