### PR TITLE
Rename package to libdrizzle-redux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 # Use and distribution licensed under the BSD license.  See
 # the COPYING file in this directory for full text.
 
-AC_INIT([libdrizzle],[5.1.4],[https://github.com/sociomantic/libdrizzle-redux/issues],[libdrizzle],[https://github.com/sociomantic/libdrizzle-redux])
+AC_INIT([libdrizzle-redux],[5.1.4],[https://github.com/sociomantic/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic/libdrizzle-redux])
 
 AC_CONFIG_AUX_DIR([build-aux])
 

--- a/libdrizzle/include.am
+++ b/libdrizzle/include.am
@@ -19,50 +19,50 @@ noinst_HEADERS+= libdrizzle/statement_local.h
 noinst_HEADERS+= libdrizzle/structs.h
 noinst_HEADERS+= libdrizzle/windows.hpp
 
-lib_LTLIBRARIES+= libdrizzle/libdrizzle.la
-libdrizzle_libdrizzle_la_SOURCES=
-libdrizzle_libdrizzle_la_LIBADD=
-libdrizzle_libdrizzle_la_LDFLAGS=
-libdrizzle_libdrizzle_la_CFLAGS= -DBUILDING_LIBDRIZZLE
-libdrizzle_libdrizzle_la_CXXFLAGS= -DBUILDING_LIBDRIZZLE
+lib_LTLIBRARIES+= libdrizzle/libdrizzle-redux.la
+libdrizzle_libdrizzle_redux_la_SOURCES=
+libdrizzle_libdrizzle_redux_la_LIBADD=
+libdrizzle_libdrizzle_redux_la_LDFLAGS=
+libdrizzle_libdrizzle_redux_la_CFLAGS= -DBUILDING_LIBDRIZZLE
+libdrizzle_libdrizzle_redux_la_CXXFLAGS= -DBUILDING_LIBDRIZZLE
 
-libdrizzle_libdrizzle_la_CFLAGS+= @OPENSSL_INCLUDES@
-libdrizzle_libdrizzle_la_CXXFLAGS+= @OPENSSL_INCLUDES@
-libdrizzle_libdrizzle_la_LDFLAGS+= @OPENSSL_LDFLAGS@
-libdrizzle_libdrizzle_la_LIBADD+= @OPENSSL_LIBS@
+libdrizzle_libdrizzle_redux_la_CFLAGS+= @OPENSSL_INCLUDES@
+libdrizzle_libdrizzle_redux_la_CXXFLAGS+= @OPENSSL_INCLUDES@
+libdrizzle_libdrizzle_redux_la_LDFLAGS+= @OPENSSL_LDFLAGS@
+libdrizzle_libdrizzle_redux_la_LIBADD+= @OPENSSL_LIBS@
 
-libdrizzle_libdrizzle_la_CFLAGS+= @PTHREAD_CFLAGS@
-libdrizzle_libdrizzle_la_CXXFLAGS+= @PTHREAD_CFLAGS@
-libdrizzle_libdrizzle_la_LIBADD+= @PTHREAD_LIBS@
+libdrizzle_libdrizzle_redux_la_CFLAGS+= @PTHREAD_CFLAGS@
+libdrizzle_libdrizzle_redux_la_CXXFLAGS+= @PTHREAD_CFLAGS@
+libdrizzle_libdrizzle_redux_la_LIBADD+= @PTHREAD_LIBS@
 
-libdrizzle_libdrizzle_la_CFLAGS+= @ZLIB_CFLAGS@
-libdrizzle_libdrizzle_la_CXXFLAGS+= @ZLIB_CFLAGS@
-libdrizzle_libdrizzle_la_LDFLAGS+= @ZLIB_LDFLAGS@
-libdrizzle_libdrizzle_la_LIBADD+= @ZLIB_LIBS@
+libdrizzle_libdrizzle_redux_la_CFLAGS+= @ZLIB_CFLAGS@
+libdrizzle_libdrizzle_redux_la_CXXFLAGS+= @ZLIB_CFLAGS@
+libdrizzle_libdrizzle_redux_la_LDFLAGS+= @ZLIB_LDFLAGS@
+libdrizzle_libdrizzle_redux_la_LIBADD+= @ZLIB_LIBS@
 
 if BUILD_WIN32
-libdrizzle_libdrizzle_la_LIBADD+= -lmingw32
-libdrizzle_libdrizzle_la_LIBADD+= -lws2_32
+libdrizzle_libdrizzle_redux_la_LIBADD+= -lmingw32
+libdrizzle_libdrizzle_redux_la_LIBADD+= -lws2_32
 endif
 
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/binlog.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/command.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/conn_uds.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/error.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/handshake.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/query.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/row.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/ssl.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/column.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/conn.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/drizzle.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/field.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/pack.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/poll.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/result.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/sha1.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/state.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/statement.cc
-libdrizzle_libdrizzle_la_SOURCES+= libdrizzle/statement_param.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/binlog.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/command.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/conn_uds.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/error.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/handshake.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/query.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/row.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/ssl.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/column.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/conn.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/drizzle.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/field.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/pack.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/poll.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/result.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/sha1.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/state.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/statement.cc
+libdrizzle_libdrizzle_redux_la_SOURCES+= libdrizzle/statement_param.cc
 
-libdrizzle_libdrizzle_la_LDFLAGS+= -version-info ${LIBDRIZZLE_LIBRARY_VERSION}
+libdrizzle_libdrizzle_redux_la_LDFLAGS+= -version-info ${LIBDRIZZLE_LIBRARY_VERSION}

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -50,11 +50,11 @@ mkdir -p $RPM_BUILD_ROOT/
 %files
 %defattr(-,root,root,-)
 %doc AUTHORS COPYING 
-%{_libdir}/libdrizzle.a
-%{_libdir}/libdrizzle.la
-%{_libdir}/libdrizzle.so
-%{_libdir}/libdrizzle.so.*
-%{_bindir}/libdrizzle-config
+%{_libdir}/libdrizzle-redux.a
+%{_libdir}/libdrizzle-redux.la
+%{_libdir}/libdrizzle-redux.so
+%{_libdir}/libdrizzle-redux.so.*
+%{_bindir}/libdrizzle-redux-config
 
 %files devel
 %defattr(-,root,root,-)

--- a/tests/unit/include.am
+++ b/tests/unit/include.am
@@ -8,7 +8,7 @@
 noinst_HEADERS+= tests/unit/common.h
 
 tests_unit_binlog_SOURCES= tests/unit/binlog.cc tests/unit/common.c
-tests_unit_binlog_LDADD= libdrizzle/libdrizzle.la
+tests_unit_binlog_LDADD= libdrizzle/libdrizzle-redux.la
 check_PROGRAMS+= tests/unit/binlog
 noinst_PROGRAMS+= tests/unit/binlog
 
@@ -22,25 +22,25 @@ check-binlog: tests/unit/binlog
 	tests/unit/binlog
 
 tests_unit_escape_SOURCES= tests/unit/escape.c
-tests_unit_escape_LDADD= libdrizzle/libdrizzle.la
+tests_unit_escape_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_escape_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/escape
 noinst_PROGRAMS+= tests/unit/escape
 
 tests_unit_insert_id_SOURCES= tests/unit/insert_id.c
-tests_unit_insert_id_LDADD= libdrizzle/libdrizzle.la
+tests_unit_insert_id_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_insert_id_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/insert_id
 noinst_PROGRAMS+= tests/unit/insert_id
 
 tests_unit_query_SOURCES= tests/unit/query.c
-tests_unit_query_LDADD= libdrizzle/libdrizzle.la
+tests_unit_query_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_query_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/query
 noinst_PROGRAMS+= tests/unit/query
 
 tests_unit_column_SOURCES= tests/unit/column.c tests/unit/common.c
-tests_unit_column_LDADD= libdrizzle/libdrizzle.la
+tests_unit_column_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_column_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/column
 noinst_PROGRAMS+= tests/unit/column
@@ -55,43 +55,43 @@ check-column: tests/unit/column
 	tests/unit/column
 
 tests_unit_numbers_SOURCES= tests/unit/numbers.c tests/unit/common.c
-tests_unit_numbers_LDADD= libdrizzle/libdrizzle.la
+tests_unit_numbers_LDADD= libdrizzle/libdrizzle-redux.la
 tests_unit_numbers_LDADD+= -lm
 nodist_EXTRA_tests_unit_numbers_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/numbers
 noinst_PROGRAMS+= tests/unit/numbers
 
 tests_unit_datetypes_SOURCES= tests/unit/datetypes.c tests/unit/common.c
-tests_unit_datetypes_LDADD= libdrizzle/libdrizzle.la
+tests_unit_datetypes_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_datetypes_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/datetypes
 noinst_PROGRAMS+= tests/unit/datetypes
 
 tests_unit_nulls_SOURCES= tests/unit/nulls.c tests/unit/common.c
-tests_unit_nulls_LDADD= libdrizzle/libdrizzle.la
+tests_unit_nulls_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_nulls_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/nulls
 noinst_PROGRAMS+= tests/unit/nulls
 
 tests_unit_row_SOURCES= tests/unit/row.c
-tests_unit_row_LDADD= libdrizzle/libdrizzle.la
+tests_unit_row_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_row_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/row
 noinst_PROGRAMS+= tests/unit/row
 
 tests_unit_version_SOURCES= tests/unit/version.c
-tests_unit_version_LDADD= libdrizzle/libdrizzle.la
+tests_unit_version_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_version_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/version
 noinst_PROGRAMS+= tests/unit/version
 
 tests_unit_version_cxx_SOURCES= tests/unit/version_cxx.cc
-tests_unit_version_cxx_LDADD= libdrizzle/libdrizzle.la
+tests_unit_version_cxx_LDADD= libdrizzle/libdrizzle-redux.la
 check_PROGRAMS+= tests/unit/version_cxx
 noinst_PROGRAMS+= tests/unit/version_cxx
 
 tests_unit_connect_SOURCES= tests/unit/connect.c
-tests_unit_connect_LDADD= libdrizzle/libdrizzle.la
+tests_unit_connect_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_connect_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/connect
 noinst_PROGRAMS+= tests/unit/connect
@@ -106,25 +106,25 @@ check-connect: tests/unit/connect
 	tests/unit/connect
 
 tests_unit_connect_uds_SOURCES= tests/unit/connect_uds.c tests/unit/common.c
-tests_unit_connect_uds_LDADD= libdrizzle/libdrizzle.la
+tests_unit_connect_uds_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_connect_uds_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/connect_uds
 noinst_PROGRAMS+= tests/unit/connect_uds
 
 tests_unit_unbuffered_query_SOURCES= tests/unit/unbuffered_query.c
-tests_unit_unbuffered_query_LDADD= libdrizzle/libdrizzle.la
+tests_unit_unbuffered_query_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_unbuffered_query_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/unbuffered_query
 noinst_PROGRAMS+= tests/unit/unbuffered_query
 
 tests_unit_statement_SOURCES= tests/unit/statement.c
-tests_unit_statement_LDADD= libdrizzle/libdrizzle.la
+tests_unit_statement_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_statement_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/statement
 noinst_PROGRAMS+= tests/unit/statement
 
 tests_unit_statement_char_SOURCES= tests/unit/statement_char.c
-tests_unit_statement_char_LDADD= libdrizzle/libdrizzle.la
+tests_unit_statement_char_LDADD= libdrizzle/libdrizzle-redux.la
 nodist_EXTRA_tests_unit_statement_char_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/statement_char
 noinst_PROGRAMS+= tests/unit/statement_char


### PR DESCRIPTION
Avoids name clashes when having parallel versions of `libdrizzle` installed. 
Requires modifying package name in relevant files used by `automake`

The valid linker name is now `libdrizzle-redux.so`
