### PR TITLE
Include memory optimizations from launchpad repo

### DIFF
--- a/libdrizzle-5.1/field_client.h
+++ b/libdrizzle-5.1/field_client.h
@@ -83,6 +83,14 @@ drizzle_field_t drizzle_field_read(drizzle_result_st *result, uint64_t *offset,
  * The return value is a newly allocated buffer and must be freed using
  * drizzle_field_free when no longer needed.
  *
+ * The buffering is done by keeping an array of char* pointers, each representing
+ * a field from a result row. Memory is (re)allocated lazily as required by the
+ * size of the field to buffer. Moreover the allocation is conservative and
+ * allocates 'new-size + 1' bytes.
+ *
+ * For further details please refer to the inline documentation in
+ * libdrizzle/field.cc
+ *
  * @param[in]  result  A result object
  * @param[in]  total   The total size of the field, to be written to by the function
  * @param[out] ret_ptr A pointer to a drizzle_return_t to store the return status into

--- a/libdrizzle/field.cc
+++ b/libdrizzle/field.cc
@@ -172,6 +172,26 @@ drizzle_field_t drizzle_field_buffer(drizzle_result_st *result, size_t *total,
     current_field= result->field_current-1;
   }
 
+  /*
+    The code below pre-allocates each field in the buffer to a statically defined
+    size to reduce the number of mallocs at the cost of a memory overhead
+
+    Experimental results did confirm that the number of allocations is halved
+    but with the caveat that the number of bytes allocated is doubled.
+
+    Given that the improvement from lazy allocation is already five orders of
+    magnitude, having minimal memory overhead is (in our opinion) more favorable
+
+    The code is kept for reference and in the case that others would like to
+    pursue this optimization further
+
+    if (result->field_buffer_sizes[current_field] == 0)
+    {
+      result->field_buffer[current_field]= (drizzle_field_t) malloc(64*1024);
+      result->field_buffer_sizes[current_field]= 64*1024;
+    }
+  */
+
   if (result->field_buffer_sizes[current_field] < (*total) + 1)
   {
     result->field_buffer[current_field]= (drizzle_field_t) realloc(result->field_buffer[current_field], (*total) + 1);

--- a/libdrizzle/result.cc
+++ b/libdrizzle/result.cc
@@ -78,6 +78,7 @@ drizzle_result_st *drizzle_result_create(drizzle_st *con)
 void drizzle_result_free(drizzle_result_st *result)
 {
   drizzle_column_st* column;
+  int64_t y;
 
   if (result == NULL)
   {
@@ -94,18 +95,13 @@ void drizzle_result_free(drizzle_result_st *result)
   if (result->options & DRIZZLE_RESULT_BUFFER_ROW)
   {
     uint64_t x;
-    int64_t y;
-    if (result->field_buffer)
+
+    for (x= 0; x < result->row_count; x++)
     {
       for (y= 0; y < (result->column_count - result->null_bitcount); y++)
       {
-        free(result->field_buffer[y]);
+        delete[] result->row_list[x][y];
       }
-    }
-    drizzle_row_free(result, result->row);
- 
-    for (x= 0; x < result->row_count; x++)
-    {
       delete[] result->row_list[x];
       if (result->null_bitmap_list != NULL)
       {
@@ -120,6 +116,17 @@ void drizzle_result_free(drizzle_result_st *result)
     free(result->row_list);
     free(result->field_sizes_list);
   }
+
+  if (result->field_buffer)
+  {
+    for (y= 0; y < (result->column_count); y++)
+    {
+      free(result->field_buffer[y]);
+    }
+    delete[] result->field_buffer;
+    delete[] result->field_buffer_sizes;
+  }
+  delete[] result->row;
 
   if (result->con)
   {

--- a/libdrizzle/result.h
+++ b/libdrizzle/result.h
@@ -69,7 +69,8 @@ struct drizzle_result_st
   uint64_t field_offset;          /* offset within field of most recently read field fragment (0 if first/only fragment) */
   uint32_t field_size;            /* size of most recently read field value or fragment of field value; max 2^24 */
   drizzle_field_t field;
-  drizzle_field_t field_buffer;
+  drizzle_field_t *field_buffer;
+  size_t *field_buffer_sizes;
 
   size_t row_list_size;
   drizzle_row_t row;

--- a/libdrizzle/row.cc
+++ b/libdrizzle/row.cc
@@ -155,16 +155,9 @@ drizzle_row_t drizzle_row_buffer(drizzle_result_st *result,
 
 void drizzle_row_free(drizzle_result_st *result, drizzle_row_t row)
 {
-  uint16_t x;
-
   if (result == NULL)
   {
     return;
-  }
-
-  for (x= 0; x < (result->column_count - result->null_bitcount); x++)
-  {
-    drizzle_field_free(row[x]);
   }
 
   if (!(result->options & DRIZZLE_RESULT_BUFFER_ROW))


### PR DESCRIPTION
This PR adds changes from https://code.launchpad.net/~linuxjedi/libdrizzle/5.1-optimize 

The changes was merged after the **v5.1.4** release which was used as base for this fork of `libdrizzle-redux`
