### PR TITLE
Extend binlogapi 

### DIFF
--- a/docs/api/binlog.rst
+++ b/docs/api/binlog.rst
@@ -153,3 +153,25 @@ Functions
    :param event: The event from the binlog stream
    :returns: The length of the raw event data
 
+.. c:function:: const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type)
+
+   Get the event type for the binlog event as string
+
+   :param event_type: A binlog event type
+   :returns: The event type of the binlog event as string
+
+.. c:function:: void drizzle_binlog_get_filename(drizzle_st *con, char *filename, int file_index)
+
+   Get the name of a binlog-file
+
+   Queries the database for a list of binlog files and copies the filename to
+   the passed buffer
+   If the file_index is invalid or no binlog files exist filename will contain an
+   empty string
+   A valid file_index is in the range [-1 to (number of binlog files -1)]
+
+   The memory (de)allocation of the filename buffer must be done by the client
+
+   :param con: Drizzle structure previously initialized with drizzle_create() or drizzle_clone()
+   :param filename: Buffer to copy filename to
+   :param file_index: Index of the binlog to retrieve

--- a/libdrizzle-5.1/binlog.h
+++ b/libdrizzle-5.1/binlog.h
@@ -193,6 +193,35 @@ const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *even
 DRIZZLE_API
 uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event);
 
+/**
+* Get the event type for the binlog event as string
+*
+* @param[in] event_type A binlog event type
+* @return The event type of the binlog event as string
+*/
+DRIZZLE_API
+const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type);
+
+/**
+ * Get the name of a binlog-file
+ *
+ * Queries the database for a list of binlog files and copies the filename to
+ * the passed buffer
+ * If the file_index is invalid or no binlog files exist filename will contain an
+ * empty string.
+ * A valid file_index is in the range [-1 to (number of binlog files -1)]
+ *
+ * The filename parameter is allocated by the function and needs to be
+ * freed by the application when finished with.
+ *
+ * @param[in] con Drizzle structure previously initialized with
+ *  drizzle_create() or drizzle_clone().
+ * @param[in,out] filename buffer to copy filename to
+ * @param[in] file_index index of the binlog to retrieve.
+ */
+DRIZZLE_API
+void drizzle_binlog_get_filename(drizzle_st *con, char **filename, int file_index);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Adds two utility function to the binlog api

`drizzle_binlog_event_type_str`
Returns the enum name of a binlog event type as const char*

`drizzle_binlog_get_filename`
The added function allows the client to retrieve the filename of a binlog specified by index.
If the index is -1, the filename of the latest binlog is returned
