### PR TITLE
Fixed integer underflow when processing large result sets using prepared statements

### DIFF
--- a/libdrizzle/state.cc
+++ b/libdrizzle/state.cc
@@ -86,6 +86,12 @@ drizzle_return_t drizzle_state_packet_read(drizzle_st *con)
 
   con->packet_size= drizzle_get_byte3(con->buffer_ptr);
 
+  if (con->buffer_size < (con->packet_size + 4))
+  {
+    con->push_state(drizzle_state_read);
+    return DRIZZLE_RETURN_OK;
+  }
+
   if (con->packet_number != con->buffer_ptr[3])
   {
     drizzle_set_error(con, "drizzle_state_packet_read",


### PR DESCRIPTION
When I was trying to buffer results from prepared statements by `drizzle_stmt_buffer`, and it gave me `DRIZZLE_RETURN_BAD_PACKET_NUMBER`: `drizzle_state_packet_read:bad packet number:54:0`

Debug log:

```
.....
DEBUG: drizzle_state_packet_read
DEBUG: buffer_size= 130, packet_size= 62, packet_number= 51
DEBUG: drizzle_state_row_read
DEBUG: drizzle_state_packet_read
DEBUG: buffer_size= 64, packet_size= 32, packet_number= 52
DEBUG: drizzle_state_row_read
DEBUG: drizzle_state_packet_read
DEBUG: buffer_size= 28, packet_size= 62, packet_number= 53
DEBUG: drizzle_state_row_read
DEBUG: drizzle_state_packet_read
** FATAL : [9] drizzle_state_packet_read:bad packet number:54:0
```

I made some modifications in `libdrizzle/state.cc` to print out `con->buffer_size`, and I got:

```
.....
DEBUG: buffer_size= 64, packet_size= 32, packet_number= 52
DEBUG: drizzle_state_row_read
DEBUG: drizzle_state_packet_read, con->buffer_size = 28
DEBUG: buffer_size= 28, packet_size= 62, packet_number= 53
DEBUG: drizzle_state_row_read
DEBUG: drizzle_state_packet_read, con->buffer_size = 18446744073709551585 <-- HERE!!
** FATAL : [9] drizzle_state_packet_read:bad packet number:54:0
```

Here we can see `con->buffer_size` was underflowed.
This happens every time when the SQL gives a large set of rows, and we can see the `buffer_size` field becomes smaller than `packet_size`(but not zero) before the underflow happens. So I guess the response packet was not complete that causes the integer underflow.

I did some fix and this commit is to solve this problem.

Test code:

``` c
#include <stdio.h>
#include <libdrizzle-5.1/libdrizzle.h>

static void fatal(drizzle_return_t ret, drizzle_st *con)
{
    fprintf(stderr, "** FATAL : [%d] %s\n", (int)ret, drizzle_error(con));
    exit(ret);
}

int main()
{
    drizzle_st *con = drizzle_create("1.1.1.1", 3306, "user", "passwd", "testdb", NULL);
    con->verbose = DRIZZLE_VERBOSE_MAX;

    drizzle_return_t ret;
    if ((ret = drizzle_connect(con)) != DRIZZLE_RETURN_OK)
        fatal(ret, con);

    const char *query= "SELECT id, state, result, timestamp FROM some_table WHERE state = ?";
    drizzle_stmt_st *stmt = drizzle_stmt_prepare(con, query, strlen(query), &ret);

    printf("params: %" PRIu16 "\n", drizzle_stmt_param_count(stmt));
    if ((ret = drizzle_stmt_set_int(stmt, 0, 1, false)) != DRIZZLE_RETURN_OK)
        fatal(ret, con);

    printf("execute\n");
    if ((ret = drizzle_stmt_execute(stmt)) != DRIZZLE_RETURN_OK)
        fatal(ret, con);

    printf("buffer\n");
    if ((ret = drizzle_stmt_buffer(stmt)) != DRIZZLE_RETURN_OK)
        fatal(ret, con);

    while ((ret = drizzle_stmt_fetch(stmt)) != DRIZZLE_RETURN_ROW_END)
    {
        size_t size;
        drizzle_return_t retv = DRIZZLE_RETURN_OK;
        const char *id = drizzle_stmt_get_string(stmt, 0, &size, &retv);
        const char *state = drizzle_stmt_get_string(stmt, 1, &size, &retv);
        const char *result = drizzle_stmt_get_string(stmt, 2, &size, &retv);
        const char *timestamp = drizzle_stmt_get_string(stmt, 3, &size, &retv);
        fprintf(stderr, "id: %s, state: %s, result: %s, timestamp: %s\n", id, state, result, timestamp);
    }

    printf("rows found: %" PRIu64 "\n", drizzle_stmt_row_count(stmt));
    drizzle_stmt_close(stmt);

    printf("quit\n");
    drizzle_quit(con);
    return 0;
}
```
