### PR TITLE
Use __func__ macro when logging functions

### DIFF
--- a/libdrizzle/binlog.cc
+++ b/libdrizzle/binlog.cc
@@ -315,7 +315,7 @@ drizzle_return_t drizzle_state_binlog_read(drizzle_st *con)
     binlog_event->raw_length= binlog_event->length= drizzle_get_byte4(con->buffer_ptr + 9);
     if (con->packet_size != binlog_event->length)
     {
-        drizzle_set_error(con, "drizzle_state_binlog_read",
+        drizzle_set_error(con, __func__,
                           "packet size error:%" PRIu32 ":%" PRIu32, con->packet_size, binlog_event->length);
         con->binlog->error_fn(DRIZZLE_RETURN_UNEXPECTED_DATA, con, con->binlog->binlog_context);
         return DRIZZLE_RETURN_UNEXPECTED_DATA;
@@ -383,7 +383,7 @@ drizzle_return_t drizzle_state_binlog_read(drizzle_st *con)
 
     if (con->packet_size != 0)
     {
-      drizzle_set_error(con, "drizzle_state_binlog_read",
+      drizzle_set_error(con, __func__,
                         "unexpected data after packet:%zu", con->buffer_size);
       con->binlog->error_fn(DRIZZLE_RETURN_UNEXPECTED_DATA, con, con->binlog->binlog_context);
       return DRIZZLE_RETURN_UNEXPECTED_DATA;

--- a/libdrizzle/column.cc
+++ b/libdrizzle/column.cc
@@ -467,7 +467,7 @@ drizzle_return_t drizzle_state_column_read(drizzle_st *con)
 
   drizzle_column_st *column;
 
-  drizzle_log_debug(con, "drizzle_state_column_read");
+  drizzle_log_debug(con, __func__);
 
   /* Assume the entire column packet will fit in the buffer. */
   if (con->buffer_size < con->packet_size)

--- a/libdrizzle/command.cc
+++ b/libdrizzle/command.cc
@@ -60,7 +60,7 @@ drizzle_return_t drizzle_state_command_write(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_command_write");
+  drizzle_log_debug(con, __func__);
 
   if (con->command_data == NULL && con->command_total != 0 &&
       con->command != DRIZZLE_COMMAND_CHANGE_USER)

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -727,7 +727,7 @@ drizzle_result_st *drizzle_command_write(drizzle_st *con,
   {
     if (con->state.raw_packet)
     {
-      drizzle_set_error(con, "drizzle_command_write",
+      drizzle_set_error(con, __func__,
                         "connection not ready");
       *ret_ptr= DRIZZLE_RETURN_NOT_READY;
       return result;
@@ -752,7 +752,7 @@ drizzle_result_st *drizzle_command_write(drizzle_st *con,
       {
         if (result == old_result)
         {
-          drizzle_set_error(con, "drizzle_command_write", "result struct already in use");
+          drizzle_set_error(con, __func__, "result struct already in use");
           *ret_ptr= DRIZZLE_RETURN_INTERNAL_ERROR;
           return result;
         }
@@ -886,7 +886,7 @@ drizzle_return_t drizzle_state_addrinfo(drizzle_st *con)
       int ret= getaddrinfo(host, port, &ai, &(tcp->addrinfo));
       if (ret != 0)
       {
-        drizzle_set_error(con, "drizzle_state_addrinfo", "getaddrinfo:%s", gai_strerror(ret));
+        drizzle_set_error(con, __func__, "getaddrinfo:%s", gai_strerror(ret));
         return DRIZZLE_RETURN_GETADDRINFO;
       }
 
@@ -914,7 +914,7 @@ drizzle_return_t drizzle_state_connect(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_connect");
+  drizzle_log_debug(con, __func__);
 
   __closesocket(con->fd);
 
@@ -1097,7 +1097,7 @@ drizzle_return_t drizzle_state_connecting(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_connecting");
+  drizzle_log_debug(con, __func__);
 
   if (con->revents & (POLLOUT | POLLERR | POLLHUP))
   {
@@ -1176,7 +1176,7 @@ drizzle_return_t drizzle_state_read(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_read");
+  drizzle_log_debug(con, __func__);
 
   if (con->buffer_size == 0)
   {
@@ -1354,7 +1354,7 @@ drizzle_return_t drizzle_state_write(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_write");
+  drizzle_log_debug(con, __func__);
 
   while (con->buffer_size != 0)
   {
@@ -1418,7 +1418,7 @@ drizzle_return_t drizzle_state_write(drizzle_st *con)
         return DRIZZLE_RETURN_LOST_CONNECTION;
       }
 
-      drizzle_set_error(con, "drizzle_state_write", "send: %s", strerror(errno));
+      drizzle_set_error(con, __func__, "send: %s", strerror(errno));
       con->last_errno= errno;
       return DRIZZLE_RETURN_ERRNO;
     }

--- a/libdrizzle/drizzle.cc
+++ b/libdrizzle/drizzle.cc
@@ -340,7 +340,7 @@ drizzle_return_t drizzle_wait(drizzle_st *con)
         continue;
       }
 
-      drizzle_set_error(con, "drizzle_wait", "poll:%d", errno);
+      drizzle_set_error(con, __func__, "poll:%d", errno);
       con->last_errno= errno;
       return DRIZZLE_RETURN_ERRNO;
     }
@@ -351,7 +351,7 @@ drizzle_return_t drizzle_wait(drizzle_st *con)
 
   if (ret == 0)
   {
-    drizzle_set_error(con, "drizzle_wait", "timeout reached");
+    drizzle_set_error(con, __func__, "timeout reached");
     return DRIZZLE_RETURN_TIMEOUT;
   }
 

--- a/libdrizzle/field.cc
+++ b/libdrizzle/field.cc
@@ -252,7 +252,7 @@ drizzle_return_t drizzle_state_field_read(drizzle_st *con)
   {
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
-  drizzle_log_debug(con, "drizzle_state_field_read");
+  drizzle_log_debug(con, __func__);
 
   if (con->buffer_size == 0)
   {

--- a/libdrizzle/handshake.cc
+++ b/libdrizzle/handshake.cc
@@ -90,7 +90,7 @@ drizzle_return_t drizzle_state_handshake_server_read(drizzle_st *con)
   {
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
-  drizzle_log_debug(con, "drizzle_state_handshake_server_read");
+  drizzle_log_debug(con, __func__);
 
   /* Assume the entire handshake packet will fit in the buffer. */
   if (con->buffer_size < con->packet_size)
@@ -101,7 +101,7 @@ drizzle_return_t drizzle_state_handshake_server_read(drizzle_st *con)
 
   if (con->packet_size < 46)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_server_read",
+    drizzle_set_error(con, __func__,
                       "bad packet size:>=46:%zu", con->packet_size);
     return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
   }
@@ -116,13 +116,13 @@ drizzle_return_t drizzle_state_handshake_server_read(drizzle_st *con)
        will be impossible and denies any attempt right away. */
     if (con->protocol_version == 255)
     {
-      drizzle_set_error(con, "drizzle_state_handshake_server_read",
+      drizzle_set_error(con, __func__,
                         "%.*s", (int)con->packet_size - 3,
                         con->buffer_ptr + 2);
       return DRIZZLE_RETURN_AUTH_FAILED;
     }
 
-    drizzle_set_error(con, "drizzle_state_handshake_server_read",
+    drizzle_set_error(con, __func__,
                       "protocol version not supported:%d",
                       con->protocol_version);
     return DRIZZLE_RETURN_PROTOCOL_NOT_SUPPORTED;
@@ -132,14 +132,14 @@ drizzle_return_t drizzle_state_handshake_server_read(drizzle_st *con)
   ptr= (unsigned char*)memchr(con->buffer_ptr, 0, con->buffer_size - 1);
   if (ptr == NULL)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_server_read",
+    drizzle_set_error(con, __func__,
                       "server version string not found");
     return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
   }
 
   if (con->packet_size < (46 + (size_t)(ptr - con->buffer_ptr)))
   {
-    drizzle_set_error(con, "drizzle_state_handshake_server_read",
+    drizzle_set_error(con, __func__,
                       "bad packet size:%zu:%zu",
                       (46 + (size_t)(ptr - con->buffer_ptr)), con->packet_size);
     return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
@@ -166,7 +166,7 @@ drizzle_return_t drizzle_state_handshake_server_read(drizzle_st *con)
 
   if (!(con->capabilities & DRIZZLE_CAPABILITIES_PROTOCOL_41))
   {
-    drizzle_set_error(con, "drizzle_state_handshake_server_read",
+    drizzle_set_error(con, __func__,
                       "protocol version not supported, must be MySQL 4.1+");
     return DRIZZLE_RETURN_PROTOCOL_NOT_SUPPORTED;
   }
@@ -192,7 +192,7 @@ drizzle_return_t drizzle_state_handshake_server_read(drizzle_st *con)
   con->buffer_size-= con->packet_size;
   if (con->buffer_size != 0)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_server_read",
+    drizzle_set_error(con, __func__,
                       "unexpected data after packet:%zu", con->buffer_size);
     return DRIZZLE_RETURN_UNEXPECTED_DATA;
   }
@@ -225,7 +225,7 @@ drizzle_return_t drizzle_state_handshake_server_write(drizzle_st *con)
   {
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
-  drizzle_log_debug(con, "drizzle_state_handshake_server_write");
+  drizzle_log_debug(con, __func__);
 
   /* Calculate max packet size. */
   con->packet_size= (uint32_t)(
@@ -244,7 +244,7 @@ drizzle_return_t drizzle_state_handshake_server_write(drizzle_st *con)
   /* Assume the entire handshake packet will fit in the buffer. */
   if ((con->packet_size + 4) > con->buffer_allocation)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_server_write",
+    drizzle_set_error(con, __func__,
                       "buffer too small:%zu", con->packet_size + 4);
     return DRIZZLE_RETURN_INTERNAL_ERROR;
   }
@@ -315,7 +315,7 @@ drizzle_return_t drizzle_state_handshake_server_write(drizzle_st *con)
   /* Make sure we packed it correctly. */
   if ((size_t)(ptr - con->buffer_ptr) != (4 + con->packet_size))
   {
-    drizzle_set_error(con, "drizzle_state_handshake_server_write",
+    drizzle_set_error(con, __func__,
                       "error packing server handshake:%zu:%zu",
                       (size_t)(ptr - con->buffer_ptr), 4 + con->packet_size);
     return DRIZZLE_RETURN_INTERNAL_ERROR;
@@ -334,7 +334,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
   {
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
-  drizzle_log_debug(con, "drizzle_state_handshake_client_read");
+  drizzle_log_debug(con, __func__);
 
   /* Assume the entire handshake packet will fit in the buffer. */
   if (con->buffer_size < con->packet_size)
@@ -346,7 +346,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
   /* This is the minimum packet size. */
   if (con->packet_size < 34)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_client_read",
+    drizzle_set_error(con, __func__,
                       "bad packet size:>=34:%zu", con->packet_size);
     return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
   }
@@ -358,7 +358,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
 
   if (!(con->capabilities & DRIZZLE_CAPABILITIES_PROTOCOL_41))
   {
-    drizzle_set_error(con, "drizzle_state_handshake_client_read",
+    drizzle_set_error(con, __func__,
                       "protocol version not supported, must be MySQL 4.1+");
     return DRIZZLE_RETURN_PROTOCOL_NOT_SUPPORTED;
   }
@@ -376,7 +376,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
   unsigned char *ptr= (unsigned char*)memchr(con->buffer_ptr, 0, con->buffer_size - 32);
   if (ptr == NULL)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_client_read",
+    drizzle_set_error(con, __func__,
                       "user string not found");
     return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
   }
@@ -391,7 +391,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
     real_size+= (size_t)(ptr - con->buffer_ptr);
     if (con->packet_size < real_size)
     {
-      drizzle_set_error(con, "drizzle_state_handshake_client_read",
+      drizzle_set_error(con, __func__,
                         "bad packet size:>=%zu:%zu", real_size,
                         con->packet_size);
       return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
@@ -413,7 +413,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
   {
     if (scramble_size != DRIZZLE_MAX_SCRAMBLE_SIZE)
     {
-      drizzle_set_error(con, "drizzle_state_handshake_client_read",
+      drizzle_set_error(con, __func__,
                         "wrong scramble size");
       return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
     }
@@ -436,7 +436,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
                                     (34 + strlen(con->user) + scramble_size));
     if (ptr == NULL)
     {
-      drizzle_set_error(con, "drizzle_state_handshake_client_read",
+      drizzle_set_error(con, __func__,
                         "db string not found");
       return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
     }
@@ -444,7 +444,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
     real_size+= ((size_t)(ptr - con->buffer_ptr) + 1);
     if (con->packet_size != real_size)
     {
-      drizzle_set_error(con, "drizzle_state_handshake_client_read",
+      drizzle_set_error(con, __func__,
                         "bad packet size:%zu:%zu", real_size, con->packet_size);
       return DRIZZLE_RETURN_BAD_HANDSHAKE_PACKET;
     }
@@ -465,7 +465,7 @@ drizzle_return_t drizzle_state_handshake_client_read(drizzle_st *con)
   con->buffer_size-= con->packet_size;
   if (con->buffer_size != 0)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_client_read",
+    drizzle_set_error(con, __func__,
                       "unexpected data after packet:%zu", con->buffer_size);
     return DRIZZLE_RETURN_UNEXPECTED_DATA;
   }
@@ -528,14 +528,14 @@ drizzle_return_t drizzle_state_handshake_client_write(drizzle_st *con)
   {
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
-  drizzle_log_debug(con, "drizzle_state_handshake_client_write");
+  drizzle_log_debug(con, __func__);
 #ifdef USE_OPENSSL
   if (con->ssl)
   {
     ssl_ret= SSL_connect(con->ssl);
     if (ssl_ret != 1)
     {
-      drizzle_set_error(con, "drizzle_state_handshake_client_write", "SSL error: %d", SSL_get_error(con->ssl, ssl_ret));
+      drizzle_set_error(con, __func__, "SSL error: %d", SSL_get_error(con->ssl, ssl_ret));
       return DRIZZLE_RETURN_SSL_ERROR;
     }
     con->ssl_state= DRIZZLE_SSL_STATE_HANDSHAKE_COMPLETE;
@@ -555,7 +555,7 @@ drizzle_return_t drizzle_state_handshake_client_write(drizzle_st *con)
   /* Assume the entire handshake packet will fit in the buffer. */
   if ((con->packet_size + 4) > con->buffer_allocation)
   {
-    drizzle_set_error(con, "drizzle_state_handshake_client_write",
+    drizzle_set_error(con, __func__,
                       "buffer too small:%zu", con->packet_size + 4);
     return DRIZZLE_RETURN_INTERNAL_ERROR;
   }
@@ -590,7 +590,7 @@ drizzle_return_t drizzle_state_handshake_client_write(drizzle_st *con)
   /* Make sure we packed it correctly. */
   if ((size_t)(ptr - con->buffer_ptr) != (4 + con->packet_size))
   {
-    drizzle_set_error(con, "drizzle_state_handshake_client_write",
+    drizzle_set_error(con, __func__,
                       "error packing client handshake:%zu:%zu",
                       (size_t)(ptr - con->buffer_ptr), 4 + con->packet_size);
     return DRIZZLE_RETURN_INTERNAL_ERROR;
@@ -608,7 +608,7 @@ drizzle_return_t drizzle_state_handshake_ssl_client_write(drizzle_st *con)
   unsigned char *ptr;
   int capabilities;
 
-  drizzle_log_debug(con, "drizzle_state_handshake_ssl_client_write");
+  drizzle_log_debug(con, __func__);
 
   /* SSL handshake packet structure */
   con->packet_size= 4   /* Capabilities */
@@ -645,7 +645,7 @@ drizzle_return_t drizzle_state_handshake_result_read(drizzle_st *con)
   {
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
-  drizzle_log_debug(con, "drizzle_state_handshake_result_read");
+  drizzle_log_debug(con, __func__);
 
   drizzle_result_st *result = drizzle_result_create(con);
 
@@ -663,7 +663,7 @@ drizzle_return_t drizzle_state_handshake_result_read(drizzle_st *con)
     {
       if (drizzle_result_eof(result))
       {
-        drizzle_set_error(con, "drizzle_state_handshake_result_read",
+        drizzle_set_error(con, __func__,
                          "old insecure authentication mechanism not supported");
         ret= DRIZZLE_RETURN_AUTH_FAILED;
       }

--- a/libdrizzle/pack.cc
+++ b/libdrizzle/pack.cc
@@ -320,7 +320,7 @@ drizzle_return_t drizzle_unpack_string(drizzle_st *con, char *buffer,
   {
     if (ret == DRIZZLE_RETURN_NULL_SIZE)
     {
-      drizzle_set_error(con, "drizzle_unpack_string",
+      drizzle_set_error(con, __func__,
                         "unexpected NULL length");
     }
 
@@ -329,7 +329,7 @@ drizzle_return_t drizzle_unpack_string(drizzle_st *con, char *buffer,
 
   if (length > con->packet_size)
   {
-    drizzle_set_error(con, "drizzle_unpack_string",
+    drizzle_set_error(con, __func__,
                            "string extends past end of packet");
     return DRIZZLE_RETURN_UNEXPECTED_DATA;
   }
@@ -443,7 +443,7 @@ static drizzle_return_t _pack_scramble_hash(drizzle_st *con,
 
   if (SHA1_DIGEST_LENGTH != DRIZZLE_MAX_SCRAMBLE_SIZE)
   {
-    drizzle_set_error(con, "_pack_scramble_hash",
+    drizzle_set_error(con, __func__,
                       "SHA1 hash size mismatch:%u:%u", SHA1_DIGEST_LENGTH,
                       DRIZZLE_MAX_SCRAMBLE_SIZE);
     return DRIZZLE_RETURN_INTERNAL_ERROR;
@@ -451,7 +451,7 @@ static drizzle_return_t _pack_scramble_hash(drizzle_st *con,
 
   if (con->scramble == NULL)
   {
-    drizzle_set_error(con, "_pack_scramble_hash",
+    drizzle_set_error(con, __func__,
                       "no scramble buffer");
     return DRIZZLE_RETURN_NO_SCRAMBLE;
   }

--- a/libdrizzle/result.cc
+++ b/libdrizzle/result.cc
@@ -412,7 +412,7 @@ drizzle_return_t drizzle_state_result_read(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_result_read");
+  drizzle_log_debug(con, __func__);
 
   /* Assume the entire result packet will fit in the buffer. */
   if (con->buffer_size < con->packet_size)

--- a/libdrizzle/row.cc
+++ b/libdrizzle/row.cc
@@ -269,7 +269,7 @@ drizzle_return_t drizzle_state_row_read(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_row_read");
+  drizzle_log_debug(con, __func__);
 
   if (con->packet_size != 0 && con->buffer_size < con->packet_size &&
     con->buffer_size < 5)

--- a/libdrizzle/ssl.cc
+++ b/libdrizzle/ssl.cc
@@ -50,13 +50,13 @@ drizzle_return_t drizzle_set_ssl(drizzle_st *con, const char *key, const char *c
 
   if (cipher)
   {
-    drizzle_set_error(con, "drizzle_set_ssl", "Cannot set the SSL cipher list");
+    drizzle_set_error(con, __func__, "Cannot set the SSL cipher list");
     return DRIZZLE_RETURN_SSL_ERROR;
   }
 
   if (SSL_CTX_load_verify_locations((SSL_CTX*)con->ssl_context, ca, capath) != 1)
   {
-    drizzle_set_error(con, "drizzle_set_ssl", "Cannot load the SSL certificate authority file");
+    drizzle_set_error(con, __func__, "Cannot load the SSL certificate authority file");
     return DRIZZLE_RETURN_SSL_ERROR;
   }
 
@@ -64,7 +64,7 @@ drizzle_return_t drizzle_set_ssl(drizzle_st *con, const char *key, const char *c
   {
     if (SSL_CTX_use_certificate_file((SSL_CTX*)con->ssl_context, cert, SSL_FILETYPE_PEM) != 1)
     {
-      drizzle_set_error(con, "drizzle_set_ssl", "Cannot load the SSL certificate file");
+      drizzle_set_error(con, __func__, "Cannot load the SSL certificate file");
       return DRIZZLE_RETURN_SSL_ERROR;
     }
 
@@ -73,13 +73,13 @@ drizzle_return_t drizzle_set_ssl(drizzle_st *con, const char *key, const char *c
 
     if (SSL_CTX_use_PrivateKey_file((SSL_CTX*)con->ssl_context, key, SSL_FILETYPE_PEM) != 1)
     {
-      drizzle_set_error(con, "drizzle_set_ssl", "Cannot load the SSL key file");
+      drizzle_set_error(con, __func__, "Cannot load the SSL key file");
       return DRIZZLE_RETURN_SSL_ERROR;
     }
 
     if (SSL_CTX_check_private_key((SSL_CTX*)con->ssl_context) != 1)
     {
-      drizzle_set_error(con, "drizzle_set_ssl", "Error validating the SSL private key");
+      drizzle_set_error(con, __func__, "Error validating the SSL private key");
       return DRIZZLE_RETURN_SSL_ERROR;
     }
   }

--- a/libdrizzle/state.cc
+++ b/libdrizzle/state.cc
@@ -76,7 +76,7 @@ drizzle_return_t drizzle_state_packet_read(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  drizzle_log_debug(con, "drizzle_state_packet_read");
+  drizzle_log_debug(con, __func__);
 
   if (con->buffer_size < 4)
   {
@@ -94,7 +94,7 @@ drizzle_return_t drizzle_state_packet_read(drizzle_st *con)
 
   if (con->packet_number != con->buffer_ptr[3])
   {
-    drizzle_set_error(con, "drizzle_state_packet_read",
+    drizzle_set_error(con, __func__,
                       "bad packet number:%u:%u", con->packet_number,
                       con->buffer_ptr[3]);
     return DRIZZLE_RETURN_BAD_PACKET_NUMBER;


### PR DESCRIPTION
Make logging of functions consistent by replacing literal function names passed as argument with `__func__` for calls to `drizzle_log_debug` and `drizzle_set_error`
