### PR TITLE
Fix clang compile errors

### DIFF
--- a/libdrizzle/drizzle.cc
+++ b/libdrizzle/drizzle.cc
@@ -306,7 +306,7 @@ drizzle_return_t drizzle_wait(drizzle_st *con)
     return DRIZZLE_RETURN_INVALID_ARGUMENT;
   }
 
-  if (!con->events == 0)
+  if (!(con->events == 0))
   {
     con->pfds[0].fd= con->fd;
     con->pfds[0].events= con->events;

--- a/libdrizzle/sha1.cc
+++ b/libdrizzle/sha1.cc
@@ -25,6 +25,7 @@
 #include "libdrizzle/common.h"
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunsafe-loop-optimizations"
 
 #define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))


### PR DESCRIPTION
Encloses condition in parentheses

Adding `-Wunknown-pragmas` to the pragma `GCC diagnostic ignored` fixes the compile error where
`-Wunsafe-loop-optimizations` is reported as **unknown warning group**.

Addresses #56
