### PR TITLE
Add clang compiler to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: cpp
 
 sudo: required
 
+os:
+  - linux
+
+compiler:
+  - gcc
+  - clang    
+
 dist: trusty
 
 services:


### PR DESCRIPTION
The PR enables CI testing for clang
