### PR TITLE
Bump version to v5.3.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 # Use and distribution licensed under the BSD license.  See
 # the COPYING file in this directory for full text.
 
-AC_INIT([libdrizzle-redux],[5.2.0],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
+AC_INIT([libdrizzle-redux],[5.3.1],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -28,7 +28,7 @@ AC_CONFIG_HEADERS([config.h:config.in])dnl Keep filename to 8.3 for MS-DOS.
 AC_CONFIG_SRCDIR([libdrizzle/drizzle.cc])
 
 #shared library versioning
-LIBDRIZZLE_LIBRARY_VERSION=9:0:0
+LIBDRIZZLE_LIBRARY_VERSION=9:1:0
 #                         | | |
 #                  +------+ | +---+
 #                  |        |     |

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -83,5 +83,50 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/libdrizzle-5.1/visibility.h
 
 %changelog
-* Wed April 1 2016 Ben Palmer <ben.palmer@sociomantic.com> - 5.2.0
-- Project Moving
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [v5.3.1] - 2016-09-21
+### Changed
+- Minor fixes to documentation, syntax and formatting
+- Fix library version for deb packaging
+- Update current and previous changelog for rpm packaging
+
+## [v5.3.0] - 2016-09-16
+### Added
+- Modify drizzle_binlog_start() so binlog data can be read with a non-blocking
+  connection
+
+### Changed
+- Update hardcoded repo location
+- Fix version number in configure script
+- Update readme and doc
+- Change location of generated documentation to top-level folder sphinx-build
+- Restructure man page doc generation
+- Bugfix where calls to drizzle_connect() would always block regardless of the
+  non_blocking option being set to true
+- Optimization of drizzle_field_buffer() so an array of drizzle_field_t pointers
+  are used to buffer fields
+- Minor fixes to .gitignore
+- Fixed integer underflow when processing large result sets using prepared
+  statements
+- Use func macro when logging functions
+- Update README with reasons for a sociomantic-tsunami fork
+- Whitespace fixes
+- Add continuous integration testing for clang compiler
+- Fix linter warnings in bootstrap.sh
+- Fix travis-ci build config for environment variables
+- Add travis-ci build status to README
+- Add unittest for event_watch_fn callback function
+- Improve documentation for binlog code example
+
+## [v5.2.0] - 2016-04-01
+### Added
+- Add callback function for poll events to client api
+
+### Changed
+- Move project repo to https://github.com/sociomantic-tsunami/libdrizzle-redux
+- Remove obsolete dependencies from deb packages
+- Rename library to libdrizzle-redux


### PR DESCRIPTION
Following the libtool guideline for updating
library version info, the ABI revision
number was incremented, resulting in the new
library version `9.1.0` (`libdrizzle-redux.so.9.0.1`)

For further details on libtool version-info
see: https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
