### PR TITLE
Fix bugs in deb build script 

### DIFF
--- a/deb/build
+++ b/deb/build
@@ -5,20 +5,20 @@ cd `dirname $0`
 
 genchangelog()
 {
-        echo "$1 ($2) `lsb_release -sc`; urgency=low"
-        echo
-	prevtag=$(git describe --abbrev=0 HEAD^)
-        git log --date=short --format="  * %s (%h, %cd)" "$prevtag"..HEAD |
-                fold --spaces --width 76 | sed 's/^\([^ ]\+\)/    \1/'
-        echo
-        echo " -- $3  `LANG=C date -R`"
+    echo "$1 ($2) `lsb_release -sc`; urgency=low"
+    echo
+    prevtag=$(git describe --abbrev=0 HEAD^)
+    git log --date=short --format="  * %s (%h, %cd)" "$prevtag"..HEAD |
+            fold --spaces --width 76 | sed 's/^\([^ ]\+\)/    \1/'
+    echo
+    echo " -- $3  `LANG=C date -R`"
 }
 
 pkgversion=$(git describe --dirty | cut -c2- |
-		sed 's/-\([0-9]\+\)-\(g[0-9a-f]\+\)/+\1~\2/' |
-		sed 's/\(~g[0-9a-f]\+\)-dirty$/-dirty\1/' |
-		sed 's/-dirty/~dirty.'`date +%Y%m%d%H%M%S`'/'
-	)-$(lsb_release -cs)
+             sed 's/-\([0-9]\+\)-\(g[0-9a-f]\+\)/+\1~\2/' |
+             sed 's/\(~g[0-9a-f]\+\)-dirty$/-dirty\1/' |
+             sed 's/-dirty/~dirty.'`date +%Y%m%d%H%M%S`'/'
+            )-$(lsb_release -cs)
 
 pkgmaint=$(echo "`git config user.name` <`git config user.email`>")
 
@@ -41,59 +41,59 @@ changelog=`mktemp`
 trap "rm -f '$changelog'; exit 1" INT TERM QUIT
 
 so_libname="./install/usr/lib/$so_filename"
+
 genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 cp $so_libname.$libversion $so_libname.$libversion.full
 strip  $so_libname.$libversion
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
-	--architecture all \
-	--maintainer "$pkgmaint" \
-	--description "Simplified API to MySQL databases" \
-	--url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
-	--vendor 'Sociomantic Labs GmbH' \
-	--license 'Simplified BSD License' \
-	--category libs \
-	--depends zlib1g \
-	--depends libstdc++6 \
-	--depends libc6 \
-	--depends libgcc1 \
-	--deb-changelog "$changelog" \
-	--deb-no-default-config-files \
-	$so_libname.$libversion=/usr/lib/ \
-	$so_libname.$lib_major=/usr/lib/
+    --architecture all \
+    --maintainer "$pkgmaint" \
+    --description "Simplified API to MySQL databases" \
+    --url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
+    --vendor 'Sociomantic Labs GmbH' \
+    --license 'Simplified BSD License' \
+    --category libs \
+    --depends zlib1g \
+    --depends libstdc++6 \
+    --depends libc6 \
+    --depends libgcc1 \
+    --deb-changelog "$changelog" \
+    --deb-no-default-config-files \
+    $so_libname.$libversion=/usr/lib/ \
+    $so_libname.$lib_major=/usr/lib/
 
 pkgname=libdrizzle-redux-dbg
 genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 build_id=`readelf -n install/usr/lib/libdrizzle-redux.so.$libversion | \
-	sed -n 's/^.*Build ID: \([a-f0-9]\{40\}\).*$/\1/p'`
+    sed -n 's/^.*Build ID: \([a-f0-9]\{40\}\).*$/\1/p'`
 debug_file=`printf $build_id | cut -b1-2`/`printf $build_id | cut -b3-`.debug
 objcopy --only-keep-debug $so_libname.$libversion.full $so_libname.$libversion.debug
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
-	--architecture all \
-	--maintainer "$pkgmaint" \
-	--description "Simplified API to MySQL databases" \
-	--url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
-	--vendor 'Sociomantic Labs GmbH' \
-	--license 'Simplified BSD License' \
-	--category debug \
-	--depends libdrizzle-redux \
-	--deb-changelog "$changelog" \
-	--deb-no-default-config-files \
-	$so_libname.$libversion.debug=/usr/lib/debug/.build-id/$debug_file
+    --architecture all \
+    --maintainer "$pkgmaint" \
+    --description "Simplified API to MySQL databases" \
+    --url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
+    --vendor 'Sociomantic Labs GmbH' \
+    --license 'Simplified BSD License' \
+    --category debug \
+    --depends libdrizzle-redux \
+    --deb-changelog "$changelog" \
+    --deb-no-default-config-files \
+    $so_libname.$libversion.debug=/usr/lib/debug/.build-id/$debug_file
 
 pkgname=libdrizzle-redux-dev
 genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
-	--architecture all \
-	--maintainer "$pkgmaint" \
-	--description "Simplified API to MySQL databases" \
-	--url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
-	--vendor 'Sociomantic Labs GmbH' \
-	--license 'Simplified BSD License' \
-	--category libdevel \
-	--depends libdrizzle-redux \
-	--deb-changelog "$changelog" \
-	--deb-no-default-config-files \
-	install/usr/include/=/usr/include/ \
-	$so_libname=/usr/lib/ \
-	install/usr/lib/libdrizzle-redux.a=/usr/lib/
-
+    --architecture all \
+    --maintainer "$pkgmaint" \
+    --description "Simplified API to MySQL databases" \
+    --url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
+    --vendor 'Sociomantic Labs GmbH' \
+    --license 'Simplified BSD License' \
+    --category libdevel \
+    --depends libdrizzle-redux \
+    --deb-changelog "$changelog" \
+    --deb-no-default-config-files \
+    install/usr/include/=/usr/include/ \
+    $so_libname=/usr/lib/ \
+    install/usr/lib/libdrizzle-redux.a=/usr/lib/

--- a/deb/build
+++ b/deb/build
@@ -22,7 +22,17 @@ pkgversion=$(git describe --dirty | cut -c2- |
 
 pkgmaint=$(echo "`git config user.name` <`git config user.email`>")
 
-libversion=$(echo $1 | sed  s/[^0-9]/./g)
+pkgname=libdrizzle-redux
+so_filename=libdrizzle-redux.so
+
+version_number=`find ./install/usr/lib/ ! -type l -name "$so_filename.*"`
+
+if [ $(echo $version_number | wc -l) != 1 ]; then
+    echo "'.so' file not found"
+    exit 1
+fi
+
+libversion=`echo $version_number | grep -o -P -e "([0-9]+\.?)+$"`
 lib_major=$(echo $libversion | cut -f1 -d .)
 lib_minor=$(echo $libversion | cut -f2 -d .)
 lib_patch=$(echo $libversion | cut -f3 -d .)
@@ -30,8 +40,7 @@ lib_patch=$(echo $libversion | cut -f3 -d .)
 changelog=`mktemp`
 trap "rm -f '$changelog'; exit 1" INT TERM QUIT
 
-pkgname=libdrizzle-redux
-so_libname=./install/usr/lib/libdrizzle-redux.so
+so_libname="./install/usr/lib/$so_filename"
 genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 cp $so_libname.$libversion $so_libname.$libversion.full
 strip  $so_libname.$libversion

--- a/deb/include.am
+++ b/deb/include.am
@@ -1,8 +1,8 @@
 # vim:ft=automake
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
-# 
-# Makefile for building deb package 
+#
+# Makefile for building deb package
 
 .PHONY: clean-deb deb install-deb release-deb
 

--- a/deb/include.am
+++ b/deb/include.am
@@ -9,7 +9,7 @@
 deb: clean-deb
 	./configure --prefix=/usr
 	$(MAKE) DESTDIR=${abs_builddir}/deb/install install
-	deb/build ${LIBDRIZZLE_LIBRARY_VERSION}
+	deb/build
 
 release-deb:
 	@read -p "Enter version (previous: $$(git describe --abbrev=0)): " version; \


### PR DESCRIPTION
The deb script did not extract the version number
generated by libtool correctly.
To fix this issue, the deb script now parses the
version  number from filename of the created .so
library file
