### PR TITLE
Read binlog data depending on socket owner

### DIFF
--- a/libdrizzle-5.1/conn.h
+++ b/libdrizzle-5.1/conn.h
@@ -249,6 +249,25 @@ DRIZZLE_API
 bool drizzle_options_get_auth_plugin(drizzle_options_st *options);
 
 /**
+ * Sets the owner of the socket connection
+ *
+ * @param[in,out] options The options object to modify
+ * @param[in] owner The owner of the socket connection
+ */
+DRIZZLE_API
+void drizzle_options_set_socket_owner(drizzle_options_st *options,
+                                      drizzle_socket_owner owner);
+
+/**
+ * Gets the owner of the socket connection
+ *
+ * @param[in] options The options object to get the value from
+ * @return The owner of the socket
+ */
+DRIZZLE_API
+drizzle_socket_owner drizzle_options_get_socket_owner(drizzle_options_st *options);
+
+/**
  * Get TCP host for a connection.
  *
  * @param[in] con Connection structure previously initialized with

--- a/libdrizzle-5.1/constants.h
+++ b/libdrizzle-5.1/constants.h
@@ -282,6 +282,15 @@ typedef enum
   DRIZZLE_SSL_STATE_HANDSHAKE_COMPLETE
 } drizzle_ssl_state_t;
 
+/**
+ * Owner of socket connection
+ */
+typedef enum
+{
+  DRIZZLE_SOCKET_OWNER_NATIVE=0,
+  DRIZZLE_SOCKET_OWNER_CLIENT
+} drizzle_socket_owner;
+
 typedef enum
 {
   DRIZZLE_EVENT_POSITION_TIMESTAMP= 0,

--- a/libdrizzle/binlog.cc
+++ b/libdrizzle/binlog.cc
@@ -154,14 +154,14 @@ drizzle_return_t drizzle_binlog_start(drizzle_binlog_st *binlog,
     ret = drizzle_wait(con);
     drizzle_result_free(result);
   }
-  else
-  {
-    // In blocking mode data is read by drizzle_state_binlog_read
-    if (ret != DRIZZLE_RETURN_OK)
-    {
-      return ret;
-    }
 
+  if (ret != DRIZZLE_RETURN_OK)
+  {
+    return ret;
+  }
+
+  if (con->options.socket_owner == DRIZZLE_SOCKET_OWNER_NATIVE)
+  {
     result->push_state(drizzle_state_binlog_read);
     result->push_state(drizzle_state_packet_read);
   }

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -327,6 +327,26 @@ bool drizzle_options_get_auth_plugin(drizzle_options_st *options)
   return options->auth_plugin;
 }
 
+void drizzle_options_set_socket_owner(drizzle_options_st *options,
+                   drizzle_socket_owner owner)
+{
+  if (options == NULL)
+  {
+    return;
+  }
+  options->socket_owner = owner;
+}
+
+drizzle_socket_owner drizzle_options_get_socket_owner(drizzle_options_st *options)
+{
+  if (options == NULL)
+  {
+    return DRIZZLE_SOCKET_OWNER_NATIVE;
+  }
+
+  return options->socket_owner;
+}
+
 const char *drizzle_host(const drizzle_st *con)
 {
   if (con == NULL)

--- a/libdrizzle/structs.h
+++ b/libdrizzle/structs.h
@@ -159,6 +159,7 @@ struct drizzle_options_st
   bool interactive;
   bool multi_statements;
   bool auth_plugin;
+  drizzle_socket_owner socket_owner;
 
   drizzle_options_st() :
     non_blocking(false),
@@ -166,7 +167,8 @@ struct drizzle_options_st
     found_rows(false),
     interactive(false),
     multi_statements(false),
-    auth_plugin(false)
+    auth_plugin(false),
+    socket_owner(DRIZZLE_SOCKET_OWNER_NATIVE)
   { }
 };
 


### PR DESCRIPTION
Addresses an issue where clients wish to do all parsing from the socket by themselves. 
