### PR TITLE
Add api function to get column type as string

### DIFF
--- a/libdrizzle-5.1/column.h
+++ b/libdrizzle-5.1/column.h
@@ -131,6 +131,15 @@ DRIZZLE_API
 drizzle_column_type_t drizzle_column_type(drizzle_column_st *column);
 
 /**
+ * Get a column type as string
+ *
+ * @param type The table column type
+ * @return The type of the column in human readable format
+ */
+DRIZZLE_API
+const char *drizzle_column_type_str(drizzle_column_type_t type);
+
+/**
  * Get flags for a column.
  */
 DRIZZLE_API

--- a/libdrizzle/column.cc
+++ b/libdrizzle/column.cc
@@ -204,6 +204,76 @@ drizzle_column_type_t drizzle_column_type(drizzle_column_st *column)
   return column->type;
 }
 
+const char *drizzle_column_type_str(drizzle_column_type_t type)
+{
+    switch (type)
+    {
+        case DRIZZLE_COLUMN_TYPE_DECIMAL:
+            return "DECIMAL";
+        case DRIZZLE_COLUMN_TYPE_TINY:
+            return "TINY";
+        case DRIZZLE_COLUMN_TYPE_SHORT:
+            return "SHORT";
+        case DRIZZLE_COLUMN_TYPE_LONG:
+            return "LONG";
+        case DRIZZLE_COLUMN_TYPE_FLOAT:
+            return "FLOAT";
+        case DRIZZLE_COLUMN_TYPE_DOUBLE:
+            return "DOUBLE";
+        case DRIZZLE_COLUMN_TYPE_NULL:
+            return "NULL";
+        case DRIZZLE_COLUMN_TYPE_TIMESTAMP:
+            return "TIMESTAMP";
+        case DRIZZLE_COLUMN_TYPE_LONGLONG:
+            return "LONGLONG";
+        case DRIZZLE_COLUMN_TYPE_INT24:
+            return "INT24";
+        case DRIZZLE_COLUMN_TYPE_DATE:
+            return "DATE";
+        case DRIZZLE_COLUMN_TYPE_TIME:
+            return "TIME";
+        case DRIZZLE_COLUMN_TYPE_DATETIME:
+            return "DATETIME";
+        case DRIZZLE_COLUMN_TYPE_YEAR:
+            return "YEAR";
+        case DRIZZLE_COLUMN_TYPE_NEWDATE:
+            return "NEWDATE";
+        case DRIZZLE_COLUMN_TYPE_VARCHAR:
+            return "VARCHAR";
+        case DRIZZLE_COLUMN_TYPE_BIT:
+            return "BIT";
+        case DRIZZLE_COLUMN_TYPE_TIMESTAMP2:
+            return "TIMESTAMP2";
+        case DRIZZLE_COLUMN_TYPE_DATETIME2:
+            return "DATETIME2";
+        case DRIZZLE_COLUMN_TYPE_TIME2:
+            return "TIME2";
+        case DRIZZLE_COLUMN_TYPE_NEWDECIMAL:
+            return "NEWDECIMAL";
+        case DRIZZLE_COLUMN_TYPE_ENUM:
+            return "ENUM";
+        case DRIZZLE_COLUMN_TYPE_SET:
+            return "SET";
+        case DRIZZLE_COLUMN_TYPE_TINY_BLOB:
+            return "TINY_BLOB";
+        case DRIZZLE_COLUMN_TYPE_MEDIUM_BLOB:
+            return "MEDIUM_BLOB";
+        case DRIZZLE_COLUMN_TYPE_LONG_BLOB:
+            return "LONG_BLOB";
+        case DRIZZLE_COLUMN_TYPE_BLOB:
+            return "BLOB";
+        case DRIZZLE_COLUMN_TYPE_VAR_STRING:
+            return "VAR_STRING";
+        case DRIZZLE_COLUMN_TYPE_STRING:
+            return "STRING";
+        case DRIZZLE_COLUMN_TYPE_GEOMETRY:
+            return "GEOMETRY";
+        default:
+            break;
+    }
+    return "UNKNOWN";
+}
+
 drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column)
 {
   if (column == NULL)

--- a/tests/unit/column.c
+++ b/tests/unit/column.c
@@ -45,6 +45,72 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
+const drizzle_column_type_t column_types[] = {
+  DRIZZLE_COLUMN_TYPE_DECIMAL,
+  DRIZZLE_COLUMN_TYPE_TINY,
+  DRIZZLE_COLUMN_TYPE_SHORT,
+  DRIZZLE_COLUMN_TYPE_LONG,
+  DRIZZLE_COLUMN_TYPE_FLOAT,
+  DRIZZLE_COLUMN_TYPE_DOUBLE,
+  DRIZZLE_COLUMN_TYPE_NULL,
+  DRIZZLE_COLUMN_TYPE_TIMESTAMP,
+  DRIZZLE_COLUMN_TYPE_LONGLONG,
+  DRIZZLE_COLUMN_TYPE_INT24,
+  DRIZZLE_COLUMN_TYPE_DATE,
+  DRIZZLE_COLUMN_TYPE_TIME,
+  DRIZZLE_COLUMN_TYPE_DATETIME,
+  DRIZZLE_COLUMN_TYPE_YEAR,
+  DRIZZLE_COLUMN_TYPE_NEWDATE,
+  DRIZZLE_COLUMN_TYPE_VARCHAR,
+  DRIZZLE_COLUMN_TYPE_BIT,
+  DRIZZLE_COLUMN_TYPE_TIMESTAMP2,
+  DRIZZLE_COLUMN_TYPE_DATETIME2,
+  DRIZZLE_COLUMN_TYPE_TIME2,
+  DRIZZLE_COLUMN_TYPE_NEWDECIMAL,
+  DRIZZLE_COLUMN_TYPE_ENUM,
+  DRIZZLE_COLUMN_TYPE_SET,
+  DRIZZLE_COLUMN_TYPE_TINY_BLOB,
+  DRIZZLE_COLUMN_TYPE_MEDIUM_BLOB,
+  DRIZZLE_COLUMN_TYPE_LONG_BLOB,
+  DRIZZLE_COLUMN_TYPE_BLOB,
+  DRIZZLE_COLUMN_TYPE_VAR_STRING,
+  DRIZZLE_COLUMN_TYPE_STRING,
+  DRIZZLE_COLUMN_TYPE_GEOMETRY
+};
+
+const char* column_type_names[] = {
+  "DECIMAL",
+  "TINY",
+  "SHORT",
+  "LONG",
+  "FLOAT",
+  "DOUBLE",
+  "NULL",
+  "TIMESTAMP",
+  "LONGLONG",
+  "INT24",
+  "DATE",
+  "TIME",
+  "DATETIME",
+  "YEAR",
+  "NEWDATE",
+  "VARCHAR",
+  "BIT",
+  "TIMESTAMP2",
+  "DATETIME2",
+  "TIME2",
+  "NEWDECIMAL",
+  "ENUM",
+  "SET",
+  "TINY_BLOB",
+  "MEDIUM_BLOB",
+  "LONG_BLOB",
+  "BLOB",
+  "VAR_STRING",
+  "STRING",
+  "GEOMETRY"
+};
+
 int main(int argc, char *argv[])
 {
   (void) argc;
@@ -108,6 +174,14 @@ int main(int argc, char *argv[])
   CHECKED_QUERY("DROP TABLE test_column.t1");
 
   tear_down_schema("test_column");
+
+  /* Check that column type is resolved to the correct string representation */
+  for (i = 0; i < 30; i++)
+  {
+    ASSERT_STREQ_(drizzle_column_type_str(column_types[i]), column_type_names[i],
+      "Column type 'DRIZZLE_COLUMN_TYPE_%s' resolved to wrong name: '%s'",
+      column_type_names[i], drizzle_column_type_str(column_types[i]));
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Adds the function 'drizzle_column_type_str' to the
libdrizzle-redux API.
The function returns a column type as a string

Adds testing of 'drizzle_column_type_str' to
existing unittest for column API