### PR TITLE
Add the ability to actually use OpenSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,8 @@ AC_CANONICAL_BUILD
 AC_ARG_PROGRAM
 AC_USE_SYSTEM_EXTENSIONS
 
+AX_ENABLE_SSL
+
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CONFIG_HEADERS([config.h:config.in])dnl Keep filename to 8.3 for MS-DOS.
@@ -63,8 +65,6 @@ AX_PROG_SPHINX_BUILD
 
 # Checks for libraries.
 AX_CXX_GCC_ABI_DEMANGLE
-
-AS_IF([test "x${TARGET_WINDOWS}" != "xtrue"],[AX_CHECK_OPENSSL])
 
 AC_PATH_ZLIB
 

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -50,6 +50,7 @@
 # define MSG_NOSIGNAL 0
 #endif
 
+#include <limits.h>
 #include <cerrno>
 
 /**
@@ -1258,7 +1259,7 @@ drizzle_return_t drizzle_state_read(drizzle_st *con)
 #ifdef USE_OPENSSL
     if (con->ssl_state == DRIZZLE_SSL_STATE_HANDSHAKE_COMPLETE)
     {
-      read_size= SSL_read(con->ssl, (char*)con->buffer_ptr + con->buffer_size, available_buffer);
+        read_size= SSL_read(con->ssl, (char*)con->buffer_ptr + con->buffer_size, (available_buffer % INT_MAX));
     }
     else
 #endif
@@ -1381,7 +1382,7 @@ drizzle_return_t drizzle_state_write(drizzle_st *con)
 #ifdef USE_OPENSSL
     if (con->ssl_state == DRIZZLE_SSL_STATE_HANDSHAKE_COMPLETE)
     {
-      write_size= SSL_write(con->ssl, con->buffer_ptr, con->buffer_size);
+      write_size= SSL_write(con->ssl, con->buffer_ptr, (con->buffer_size % INT_MAX));
     }
     else
 #endif

--- a/libdrizzle/drizzle.cc
+++ b/libdrizzle/drizzle.cc
@@ -48,6 +48,10 @@
 #include <cerrno>
 #include <pthread.h>
 
+#if defined(USE_OPENSSL)
+#include <openssl/err.h>
+#endif
+
 /**
  * @addtogroup drizzle_static Static Drizzle Declarations
  * @ingroup drizzle

--- a/m4/ax_enable_ssl.m4
+++ b/m4/ax_enable_ssl.m4
@@ -1,0 +1,44 @@
+# SYNOPSIS
+#
+#   AX_ENABLE_SSL()
+#
+# DESCRIPTION
+#
+#   Add a feature named ssl, which is enabled by default on all platforms but Windows.
+#   If enabled, uses `AX_CHECK_OPENSSL` to set the `LDFLAGS`, `LIBS` and `CPPFLAGS`,
+#   as well as defining `USE_OPENSSL` inside `config.h`
+#
+# LICENSE
+#
+#   Copyright (c) 2016 Sociomantic Labs, All rights reserved
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+AC_DEFUN([AX_ENABLE_SSL], [
+    # SSL support, for encrypted connections
+    # Enabled by default on non-Windows platform
+    # Note: We use `--enable-ssl` for the *feature*,
+    # but AX_CHECK_OPENSSL uses `--with-openssl=dir` for the root directory
+    AC_ARG_ENABLE([ssl],
+                  AS_HELP_STRING([--disable-ssl], [Disable support for encrypted connection, using OpenSSL]))
+
+    AS_IF([test "x${enable_ssl}" != "xno"], [
+            AS_IF([test "x${TARGET_WINDOWS}" != "xtrue"],
+                  [AX_CHECK_OPENSSL
+                  AC_DEFINE([USE_OPENSSL], [], [Support for encrypted connection is enabled])
+                  LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+                  LIBS="$OPENSSL_LIBS $LIBS"
+                  CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"],
+                  # On Windows we disable it by default
+                  [AS_IF([test "x${enable_ssl}" = "xyes"],
+                         [AX_CHECK_OPENSSL
+                         AC_DEFINE([USE_OPENSSL], [], [Support for encrypted connection is enabled])
+                         LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+                         LIBS="$OPENSSL_LIBS $LIBS"
+                         CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"])]
+                 )
+    ])
+])


### PR DESCRIPTION
Before, it was not possible to enable OpenSSL support in libdrizzle-redux since the configure script didn't support enabling it (though it required openssl to be installed).

Expected results (and performed tests, on linux):
- `./configure`
- `./configure --enable-ssl[=yes]`
- `./configure --disable-ssl` (or `./configure --enable-ssl=no`)

Followed by `ldd libdrizzle/.libs/libdrizzle-redux.so`

In the first and second case, I get:
```
	linux-vdso.so.1 =>  (0x00007fffc69e3000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f235b7f1000)
	libssl.so.1.0.0 => /lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007f235b592000)
	libcrypto.so.1.0.0 => /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f235b1b6000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f235aea4000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f235ab9e000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f235a7d9000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f235a5c2000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f235a3be000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f235bc25000)
```

Before this P.R., and with the third version, I get:
```
	linux-vdso.so.1 =>  (0x00007ffecefbd000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f51f80c1000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f51f7daf000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f51f7aa9000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f51f76e4000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f51f74cd000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f51f84f4000)
```