### PR TITLE
Update documentation for v5.4.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,10 @@ gcc        | >=4.8.x
 autoconf   | >=2.61
 zlib1g-dev | >=0.13.x
 libtool    | >=2.x
+openssl<sup>1</sup> | >=v1.x
+
+<sup>1</sup> openssl is needed if libdrizzle-redux is compiled with support for
+SSL connections.
 
 New Features
 ============

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -15,6 +15,9 @@ Alternatively you can build and customize::
    make
    make install
 
+Please check the `RELEASE NOTES`_ for a list of dependencies specific to the
+version of the library you are trying to compile.
+
 .. _test-suite:
 
 Running the Test Suite
@@ -87,3 +90,5 @@ this assumes that the library is in your library and include paths::
    gcc app.c -oapp -ldrizzle-redux -lpthread
 
 A tool called **libdrizzle-redux_config** is included to also assist with this.
+
+.. _RELEASE NOTES: https://github.com/sociomantic-tsunami/libdrizzle-redux/releases


### PR DESCRIPTION
- add openssl to dependencies in RELEASE NOTES
- add link to release notes in compilation doc

Addresses #80 

