### PR TITLE
HOTFIX for travis-ci build environment update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,19 @@ os:
 
 compiler:
   - gcc
-  - clang    
+  - clang
 
 dist: trusty
 
 services:
   - mysql
 
-## The following environment variables are required for 
-#  running unittests 
-#  Environment variables can be defined in the repository, but 
-#  are overridden by values in .travis.yml. 
-#  
-#  Please refer to the section 'script' for info on 
+## The following environment variables are required for
+#  running unittests
+#  Environment variables can be defined in the repository, but
+#  are overridden by values in .travis.yml.
+#
+#  Please refer to the section 'script' for info on
 #  SKIP_TEST_ON_ERROR
 env:
   - MYSQL_SERVER=127.0.0.1 \
@@ -37,7 +37,7 @@ addons:
     - mysql-client-5.6
     - mysql-server-5.6
 
-before_install: 
+before_install:
   - gem install fpm
 
 ## This script runs before the compiling
@@ -49,14 +49,14 @@ before_script:
   - sudo service mysql stop
   - sudo sed  -i 's/\[mysqld\]/[mysqld]\nserver-id = 1\nlog-bin = mysqlbin\nbinlog-format = ROW\n/g' /etc/mysql/my.cnf
   - sudo service mysql start 
-  - mysqld --print-defaults 
+  - mysqld --print-defaults
 
-## Build steps 
-#  - compile project 
+## Build steps
+#  - compile project
 #  - run all tests with 'make check'
-# 
+#
 #  Please note that test fails on first error as default
-#  To skip errors and fail silently set environment variable: 
+#  To skip errors and fail silently set environment variable:
 #    SKIP_TEST_ON_ERROR=1
 script:
   - autoreconf -fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ compiler:
 dist: trusty
 
 services:
-  - mysql
+ - mysql-5.6
 
 ## The following environment variables are required for
 #  running unittests
@@ -28,17 +28,17 @@ env:
     SKIP_TEST_ON_ERROR=0
 
 ## Defines packages to be installed by apt
-#  Version is specified since some tests require MySQL >=5.6 
-addons:
-  apt:
-    packages:
-    - mysql-client-core-5.6 
-    - mysql-server-core-5.6
-    - mysql-client-5.6
-    - mysql-server-5.6
+#  2016/12/01 - mysql-5.6 was added to the default stack
+#  for sudo enabled trusty builds,
+#  The section is kept for reference since any additional packages
+#  would still need to go into this section
+#addons:
+#  apt:
+#    packages:
 
 before_install:
   - gem install fpm
+  - mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('')"
 
 ## This script runs before the compiling
 #  1. Stop MySQL server
@@ -46,9 +46,8 @@ before_install:
 #  3. Start MySQL server
 #  4. Print mysql config for debug purposes
 before_script:
-  - sudo service mysql stop
-  - sudo sed  -i 's/\[mysqld\]/[mysqld]\nserver-id = 1\nlog-bin = mysqlbin\nbinlog-format = ROW\n/g' /etc/mysql/my.cnf
-  - sudo service mysql start 
+  - sudo sed  -i 's/\[mysqld\]/[mysqld]\nserver-id = 1\nlog-bin = mysqlbin\nbinlog-format = ROW\n/g' /etc/mysql-5.6/my.cnf
+  - sudo service mysql-5.6 restart
   - mysqld --print-defaults
 
 ## Build steps


### PR DESCRIPTION
An update to the build environment caused
all builds to fail.
https://docs.travis-ci.com/user/build-environment-updates/2016-12-01/#Details

The patch applies fixes given in this issue:
https://github.com/travis-ci/travis-ci/issues/6961
- changes travis script to reflect change of service and
   install path to mysql-5.6
- set password was set for root@localhost
- remove apt install of mysql as it's now in the build
   stack by default