### PR TITLE
Revert renaming of mysql service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ compiler:
 dist: trusty
 
 services:
- - mysql-5.6
+ - mysql
 
 ## The following environment variables are required for
 #  running unittests
@@ -46,8 +46,8 @@ before_install:
 #  3. Start MySQL server
 #  4. Print mysql config for debug purposes
 before_script:
-  - sudo sed  -i 's/\[mysqld\]/[mysqld]\nserver-id = 1\nlog-bin = mysqlbin\nbinlog-format = ROW\n/g' /etc/mysql-5.6/my.cnf
-  - sudo service mysql-5.6 restart
+  - sudo sed  -i 's/\[mysqld\]/[mysqld]\nserver-id = 1\nlog-bin = mysqlbin\nbinlog-format = ROW\n/g' /etc/mysql/my.cnf
+  - sudo service mysql restart
   - mysqld --print-defaults
 
 ## Build steps

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 # Use and distribution licensed under the BSD license.  See
 # the COPYING file in this directory for full text.
 
-AC_INIT([libdrizzle-redux],[5.3.3],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
+AC_INIT([libdrizzle-redux],[5.3.4],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -28,7 +28,7 @@ AC_CONFIG_HEADERS([config.h:config.in])dnl Keep filename to 8.3 for MS-DOS.
 AC_CONFIG_SRCDIR([libdrizzle/drizzle.cc])
 
 #shared library versioning
-LIBDRIZZLE_LIBRARY_VERSION=9:2:0
+LIBDRIZZLE_LIBRARY_VERSION=9:3:0
 #                         | | |
 #                  +------+ | +---+
 #                  |        |     |

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -84,6 +84,9 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/libdrizzle-5.1/visibility.h
 
 %changelog
+* Fri Dec 02 2016 Andreas Bok Andersen <andreas.bok@sociomantic.com> - 5.3.4
+- Fix broken travis-ci build
+
 * Fri Dec 02 2016 Andreas Bok Andersen <andreas.bok@sociomantic.com> - 5.3.3
 - Fix .travis.yml file after travis-ci build environment update
 


### PR DESCRIPTION
The naming of tje preinstalled version of mysql 5.6
was changed from mysql-5.6 to mysql