### PR TITLE
Fix allocation bug in drizzle_binlog_get_filename

### DIFF
--- a/libdrizzle/binlog.cc
+++ b/libdrizzle/binlog.cc
@@ -493,9 +493,10 @@ void drizzle_binlog_get_filename(drizzle_st *con, char **filename, int file_inde
                             row_count - 1 : file_index;
 
     drizzle_row_t row = drizzle_row_index(result, row_index);
-    *filename =( char*)realloc(*filename, strlen(row[0]));
-    memcpy(*filename, row[0], strlen(row[0]));
-    *filename[strlen(row[0])] = '\0';
+    size_t len = strlen(row[0]);
+    *filename = (char*)realloc(*filename, len + 1);
+    memcpy(*filename, row[0], len);
+    (*filename)[len] = '\0';
   }
 
   drizzle_result_free(result);

--- a/tests/unit/binlog.cc
+++ b/tests/unit/binlog.cc
@@ -76,9 +76,14 @@ int main(int argc, char *argv[])
 
   set_up_connection();
 
+  char *binlog_file;
+  drizzle_binlog_get_filename(con, &binlog_file, -1);
+
   binlog= drizzle_binlog_init(con, binlog_event, binlog_error, NULL, true);
-  ret= drizzle_binlog_start(binlog, 0, "", 0);
+  ret= drizzle_binlog_start(binlog, 0, binlog_file, 0);
   SKIP_IF_(ret == DRIZZLE_RETURN_ERROR_CODE, "Binlog is not open?: %s(%s)", drizzle_error(con), drizzle_strerror(ret));
   ASSERT_EQ_(DRIZZLE_RETURN_EOF, ret, "Drizzle binlog start failure: %s(%s)", drizzle_error(con), drizzle_strerror(ret));
+
+  free(binlog_file);
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Allocate length of buffer to `|filename| + 1` to make
the string correctly '\0' terminated

Add test of `drizzle_binlog_get_filename` to the binlog unittest