### PR TITLE
Use TCP keep alive to prevent connection freezing on slow connections

### DIFF
--- a/libdrizzle-5.1/conn.h
+++ b/libdrizzle-5.1/conn.h
@@ -141,6 +141,51 @@ DRIZZLE_API
 void drizzle_options_destroy(drizzle_options_st *options);
 
 /**
+ * Create a new socket options object with the specified values
+ *
+ * @param[in] _wait_timeout The timeout (in seconds) for setsockopt calls with
+ *  option values: SO_SNDTIMEO, SO_RCVTIMEO, SO_LINGER
+ * @param[in] _keepidle The time (in seconds) the connection needs to remain
+ *  idle before TCP starts sending keepalive probes
+ * @param[in] _keepcnt The maximum number of keepalive probes TCP should send
+ *  before dropping the connection.
+ * @param[in] _keepintvl The time (in seconds) between individual keepalive probes
+ * @return The new socket options object
+ */
+DRIZZLE_API
+drizzle_socket_options_st *drizzle_socket_options_create(int wait_timeout,
+                                                         int keepidle,
+                                                         int keepcnt,
+                                                         int keepintvl);
+
+/**
+ * Sets/Unsets keepalive option on a connection object's socket
+ *
+ * @param[in] con Connection structure previously initialized with
+ *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] keep_alive Set to 1 (enabled) or 0 (disabled)
+ */
+DRIZZLE_API
+void drizzle_socket_set_keepalive(drizzle_st *con, int keepalive);
+
+/**
+ * Destroys a socket options object
+ * @param[in] options The options object to be destroyed
+ */
+DRIZZLE_API
+void drizzle_socket_options_destroy(drizzle_socket_options_st *options);
+
+/**
+ * Sets socket options for a connection object
+ *
+ * @param[in] con Connection structure previously initialized with
+ *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] options The options object to set
+ */
+DRIZZLE_API
+void drizzle_socket_set_options(drizzle_st *con, drizzle_socket_options_st *options);
+
+/**
  * Sets/unsets non-blocking connect option
  *
  * @param[in,out] options The options object to modify

--- a/libdrizzle-5.1/constants.h
+++ b/libdrizzle-5.1/constants.h
@@ -571,6 +571,7 @@ typedef struct drizzle_tcp_st drizzle_tcp_st;
 typedef struct drizzle_uds_st drizzle_uds_st;
 typedef struct drizzle_st drizzle_st;
 typedef struct drizzle_options_st drizzle_options_st;
+typedef struct drizzle_socket_options_st drizzle_socket_options_st;
 typedef struct drizzle_result_st drizzle_result_st;
 typedef struct drizzle_column_st drizzle_column_st;
 typedef struct drizzle_binlog_st drizzle_binlog_st;

--- a/libdrizzle-5.1/structs.h
+++ b/libdrizzle-5.1/structs.h
@@ -38,7 +38,7 @@
 #pragma once
 
 #ifdef __cplusplus
-struct drizzle_st;
+struct drizzle_socket_options_st;
 struct drizzle_tcp_st;
 struct drizzle_uds_st;
 struct drizzle_st;

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -220,6 +220,38 @@ void drizzle_options_destroy(drizzle_options_st *options)
   delete options;
 }
 
+drizzle_socket_options_st *drizzle_socket_options_create(int wait_timeout,
+                                                         int keepidle,
+                                                         int keepcnt,
+                                                         int keepintvl)
+{
+  return new (std::nothrow) drizzle_socket_options_st(wait_timeout, keepidle,
+    keepcnt, keepintvl);
+}
+
+void drizzle_socket_set_keepalive(drizzle_st *con, int keepalive)
+{
+  if (con == NULL)
+  {
+    return;
+  }
+  con->socket_options.keepalive = keepalive;
+}
+
+void drizzle_socket_options_destroy(drizzle_socket_options_st *options)
+{
+  delete options;
+}
+
+void drizzle_socket_set_options(drizzle_st *con, drizzle_socket_options_st *options)
+{
+  if (con == NULL)
+  {
+    return;
+  }
+  con->socket_options = *options;
+}
+
 void drizzle_options_set_non_blocking(drizzle_options_st *options, bool state)
 {
   if (options == NULL)

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -1497,6 +1497,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
 {
   struct linger linger;
   struct timeval waittime;
+  const socklen_t optlen_int = sizeof(int);
 
   assert(con);
   if (con == NULL)
@@ -1528,9 +1529,9 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   int ret= 1;
 
 #ifdef _WIN32
-  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_NODELAY, (const char*)&ret, (socklen_t)sizeof(int));
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_NODELAY, (const char*)&ret, optlen_int);
 #else
-  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_NODELAY, &ret, (socklen_t)sizeof(int));
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_NODELAY, &ret, optlen_int);
 #endif /* _WIN32 */
 
   if (ret == -1 && errno != EOPNOTSUPP)
@@ -1540,7 +1541,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   }
 
   linger.l_onoff= 1;
-  linger.l_linger= DRIZZLE_DEFAULT_SOCKET_TIMEOUT;
+  linger.l_linger= con->socket_options.wait_timeout;
 
 #ifdef _WIN32
   ret= setsockopt(con->fd, SOL_SOCKET, SO_LINGER, (const char*)&linger,
@@ -1556,7 +1557,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
     return DRIZZLE_RETURN_ERRNO;
   }
 
-  waittime.tv_sec= DRIZZLE_DEFAULT_SOCKET_TIMEOUT;
+  waittime.tv_sec= con->socket_options.wait_timeout;
   waittime.tv_usec= 0;
 
 #ifdef _WIN32
@@ -1588,11 +1589,68 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
     return DRIZZLE_RETURN_ERRNO;
   }
 
+#ifdef _WIN32
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_KEEPALIVE,
+                  (const char*)&con->socket_options.keepalive, optlen_int);
+#else
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_KEEPALIVE,
+                  &con->socket_options.keepalive, optlen_int);
+#endif /* _WIN32 */
+
+  if (ret == -1 && errno != ENOPROTOOPT)
+  {
+    drizzle_set_error(con, __func__,
+                      "setsockopt:SO_KEEPALIVE:%s", strerror(errno));
+    return DRIZZLE_RETURN_ERRNO;
+  }
+
+#ifdef _WIN32
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPIDLE,
+                  (const char*)&con->socket_options.keepidle, optlen_int);
+#else
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPIDLE,
+                  &con->socket_options.keepidle, optlen_int);
+#endif /* _WIN32 */
+
+  if (ret == -1 && errno != EOPNOTSUPP)
+  {
+    drizzle_set_error(con, __func__, "setsockopt:TCP_KEEPIDLE:%s", strerror(errno));
+    return DRIZZLE_RETURN_ERRNO;
+  }
+
+#ifdef _WIN32
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPCNT,
+                  (const char*)&con->socket_options.keepcnt, optlen_int);
+#else
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPCNT, &con->socket_options.keepcnt,
+                  optlen_int);
+#endif /* _WIN32 */
+
+  if (ret == -1 && errno != EOPNOTSUPP)
+  {
+    drizzle_set_error(con, __func__, "setsockopt:TCP_KEEPCNT:%s", strerror(errno));
+    return DRIZZLE_RETURN_ERRNO;
+  }
+
+#ifdef _WIN32
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPINTVL,
+                  (const char*)&con->socket_options.keepintvl, optlen_int);
+#else
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPINTVL,
+                  &con->socket_options.keepintvl, optlen_int);
+#endif /* _WIN32 */
+
+  if (ret == -1 && errno != EOPNOTSUPP)
+  {
+    drizzle_set_error(con, __func__, "setsockopt:TCP_KEEPINTVL:%s", strerror(errno));
+    return DRIZZLE_RETURN_ERRNO;
+  }
+
   ret= DRIZZLE_DEFAULT_SOCKET_SEND_SIZE;
 #ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDBUF, (const char*)&ret, (socklen_t)sizeof(int));
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDBUF, (const char*)&ret, optlen_int);
 #else
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDBUF, &ret, (socklen_t)sizeof(int));
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDBUF, &ret, optlen_int);
 #endif /* _WIN32 */
   if (ret == -1)
   {
@@ -1602,9 +1660,9 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
 
   ret= DRIZZLE_DEFAULT_SOCKET_RECV_SIZE;
 #ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVBUF, (const char*)&ret, (socklen_t)sizeof(int));
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVBUF, (const char*)&ret, optlen_int);
 #else
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVBUF, &ret, (socklen_t)sizeof(int));
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVBUF, &ret, optlen_int);
 #endif /* _WIN32 */
   if (ret == -1)
   {
@@ -1613,7 +1671,8 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   }
 
 #if defined(SO_NOSIGPIPE)
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_NOSIGPIPE, static_cast<void *>(&ret), sizeof(int));
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_NOSIGPIPE, static_cast<void *>(&ret),
+                  optlen_int);
 
   if (ret == -1)
   {

--- a/libdrizzle/structs.h
+++ b/libdrizzle/structs.h
@@ -149,8 +149,50 @@ struct drizzle_uds_st
 
 /**
  * @ingroup drizzle_con
+ *
+ * Options for the socket connection
  */
 
+struct drizzle_socket_options_st
+{
+  public:
+    int wait_timeout;
+    int keepalive;
+    int keepidle;
+    int keepcnt;
+    int keepintvl;
+
+  /**
+   * Constructor
+   *
+   * @param[in] _wait_timeout The timeout (in seconds) for setsockopt calls with
+   *  option values: SO_SNDTIMEO, SO_RCVTIMEO, SO_LINGER
+   * @param[in] _keepalive The flag which disables/enables keepalive
+   * @param[in] _keepidle The time (in seconds) the connection needs to remain
+   *  idle before TCP starts sending keepalive probes
+   * @param[in] _keepcnt The maximum number of keepalive probes TCP should send
+   *  before dropping the connection.
+   * @param[in] _keepintvl The time (in seconds) between individual keepalive
+   *  probes
+   */
+    drizzle_socket_options_st(
+      int _wait_timeout = DRIZZLE_DEFAULT_SOCKET_TIMEOUT,
+      int _keepalive = 1,
+      int _keepidle = 5,
+      int _keepcnt = 3,
+      int _keepintvl = 3)
+    {
+      this->wait_timeout = _wait_timeout;
+      this->keepalive = _keepalive;
+      this->keepidle = _keepidle;
+      this->keepcnt = _keepcnt;
+      this->keepintvl = _keepintvl;
+    }
+};
+
+/**
+ * @ingroup drizzle_con
+ */
 struct drizzle_options_st
 {
   bool non_blocking;
@@ -204,6 +246,7 @@ struct drizzle_st
   } state;
 
   drizzle_options_st options;
+  drizzle_socket_options_st socket_options;
   drizzle_socket_t socket_type;
   drizzle_status_t status;
   uint32_t max_packet_size;

--- a/tests/unit/connect.c
+++ b/tests/unit/connect.c
@@ -54,6 +54,9 @@ int main(int argc, char *argv[])
                                   getenv("MYSQL_SCHEMA"), 0);
   ASSERT_NOT_NULL_(con, "Drizzle connection object creation error");
 
+  drizzle_socket_options_st *opts = drizzle_socket_options_create(10, 5, 3, 3);
+  drizzle_socket_set_options(con, opts);
+
   drizzle_return_t ret= drizzle_connect(con);
   if (ret == DRIZZLE_RETURN_COULD_NOT_CONNECT)
   {


### PR DESCRIPTION
The mysql connection could indefinately freeze when in non-blocking mode
and on a bad internet connection. Set the TCP keep alive option to keep
the connection alive.

In addition the following other options are set:
Idle time in seconds after which to send keep alive probes - 3 seconds
Maximum number of keep alive probes before the connection is declared
dead and dropped - 3
Time in seconds between keep alive probes - 3