### PR TITLE
Use TCP keep alive to prevent connection freezing on slow connections V2

### DIFF
--- a/libdrizzle-5.1/conn.h
+++ b/libdrizzle-5.1/conn.h
@@ -141,6 +141,61 @@ DRIZZLE_API
 void drizzle_options_destroy(drizzle_options_st *options);
 
 /**
+ * Sets several options for the socket connection
+ *
+ * @param[in] options An initialized options structure
+ * @param[in] wait_timeout The timeout (in seconds) for setsockopt calls with
+ *  option values: SO_SNDTIMEO, SO_RCVTIMEO, SO_LINGER
+ * @param[in] keepidle The time (in seconds) the connection needs to remain
+ *  idle before TCP starts sending keepalive probes
+ * @param[in] keepcnt The maximum number of keepalive probes TCP should send
+ *  before dropping the connection.
+ * @param[in] keepintvl The time (in seconds) between individual keepalive probes
+ * @return The new socket options object
+ */
+DRIZZLE_API
+void drizzle_socket_set_options(drizzle_options_st *options, int wait_timeout,
+                                int keepidle, int keepcnt, int keepintvl);
+
+/**
+ * Sets the value of a socket option. The available options to set are:
+ *
+ *  DRIZZLE_SOCKET_OPTION_TIMEOUT : The timeout (in seconds) for setsockopt calls
+ *                                  with option values: SO_SNDTIMEO, SO_RCVTIMEO,
+ *                                  SO_LINGER
+ *
+ *  DRIZZLE_SOCKET_OPTION_KEEPIDLE : The time (in seconds) the connection needs
+ *                                   to remain idle before TCP starts sending
+ *                                   keepalive probes
+ *
+ *  DRIZZLE_SOCKET_OPTION_KEEPCNT : The maximum number of keepalive probes TCP
+ *                                  should send before dropping the connection.
+ *
+ *  DRIZZLE_SOCKET_OPTION_KEEPINTVL : The time (in seconds) between individual
+ *                                    keepalive probes
+ *
+ * @param[in] con Connection structure previously initialized with
+ *                drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] option the option to set the value for
+ * @param[in] value the value to set
+ */
+DRIZZLE_API
+void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option,
+                               int value);
+
+/**
+ * Gets the value of a socket option. See drizzle_socket_set_options() for a
+ * description of the available options
+ *
+ * @param[in] con Connection structure previously initialized with
+ *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] option option to get the value for
+ * @return The value of the option, or -1 if the specified option doesn't exist
+ */
+DRIZZLE_API
+int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option option);
+
+/**
  * Sets/unsets non-blocking connect option
  *
  * @param[in,out] options The options object to modify

--- a/libdrizzle-5.1/constants.h
+++ b/libdrizzle-5.1/constants.h
@@ -291,6 +291,18 @@ typedef enum
   DRIZZLE_SOCKET_OWNER_CLIENT
 } drizzle_socket_owner;
 
+/**
+ * @ingroup drizzle_con
+ * Available options to set for the socket connection
+ */
+typedef enum
+{
+  DRIZZLE_SOCKET_OPTION_KEEPIDLE=4,
+  DRIZZLE_SOCKET_OPTION_KEEPCNT,
+  DRIZZLE_SOCKET_OPTION_KEEPINTVL,
+  DRIZZLE_SOCKET_OPTION_TIMEOUT
+} drizzle_socket_option;
+
 typedef enum
 {
   DRIZZLE_EVENT_POSITION_TIMESTAMP= 0,

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -220,6 +220,76 @@ void drizzle_options_destroy(drizzle_options_st *options)
   delete options;
 }
 
+void drizzle_socket_set_options(drizzle_options_st *options, int wait_timeout,
+                                int keepidle, int keepcnt, int keepintvl)
+{
+  if (options == NULL)
+  {
+    return;
+  }
+  options->wait_timeout = wait_timeout;
+  options->keepidle = keepidle;
+  options->keepcnt = keepcnt;
+  options->keepintvl = keepintvl;
+}
+
+void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option,
+  int value)
+{
+  if (con == NULL)
+  {
+    return;
+  }
+
+  switch (option)
+  {
+    case DRIZZLE_SOCKET_OPTION_TIMEOUT:
+      con->options.wait_timeout = value;
+      break;
+
+    case DRIZZLE_SOCKET_OPTION_KEEPIDLE:
+      con->options.keepidle = value;
+      break;
+
+    case DRIZZLE_SOCKET_OPTION_KEEPCNT:
+      con->options.keepcnt = value;
+      break;
+
+    case DRIZZLE_SOCKET_OPTION_KEEPINTVL:
+      con->options.keepintvl = value;
+      break;
+
+    default:
+      break;
+  }
+}
+
+int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option option)
+{
+  if (con == NULL)
+  {
+    return -1;
+  }
+
+  switch (option)
+  {
+    case DRIZZLE_SOCKET_OPTION_TIMEOUT:
+      return con->options.wait_timeout;
+
+    case DRIZZLE_SOCKET_OPTION_KEEPIDLE:
+      return con->options.keepidle;
+
+    case DRIZZLE_SOCKET_OPTION_KEEPCNT:
+      return con->options.keepcnt;
+
+    case DRIZZLE_SOCKET_OPTION_KEEPINTVL:
+      return con->options.keepintvl;
+
+    default:
+      return -1;
+  }
+}
+
 void drizzle_options_set_non_blocking(drizzle_options_st *options, bool state)
 {
   if (options == NULL)

--- a/libdrizzle/structs.h
+++ b/libdrizzle/structs.h
@@ -160,6 +160,10 @@ struct drizzle_options_st
   bool multi_statements;
   bool auth_plugin;
   drizzle_socket_owner socket_owner;
+  int wait_timeout;
+  int keepidle;  // default value under linux: 7200
+  int keepcnt;   // default value under linux: 75
+  int keepintvl; // default value under linux: 9
 
   drizzle_options_st() :
     non_blocking(false),
@@ -168,7 +172,11 @@ struct drizzle_options_st
     interactive(false),
     multi_statements(false),
     auth_plugin(false),
-    socket_owner(DRIZZLE_SOCKET_OWNER_NATIVE)
+    socket_owner(DRIZZLE_SOCKET_OWNER_NATIVE),
+    wait_timeout(DRIZZLE_DEFAULT_SOCKET_TIMEOUT),
+    keepidle(7200),
+    keepcnt(75),
+    keepintvl(9)
   { }
 };
 


### PR DESCRIPTION
The mysql connection could indefinately freeze when in non-blocking mode
and on a bad internet connection. Set the TCP keep alive option to keep
the connection alive.

Extends the existing drizzle_options_st struct with members to needed to configure
the TCP keepalive for the socket connection.