### PR TITLE
Bugfix handshake error packet

### DIFF
--- a/libdrizzle/binlog.cc
+++ b/libdrizzle/binlog.cc
@@ -297,29 +297,11 @@ drizzle_return_t drizzle_state_binlog_read(drizzle_st *con)
     con->binlog->error_fn(DRIZZLE_RETURN_EOF, con, con->binlog->binlog_context);
     return DRIZZLE_RETURN_EOF;
   }
-  else if (con->buffer_ptr[0] == 255)
+  else if (drizzle_check_unpack_error(con))
   {
-    con->result->error_code= drizzle_get_byte2(con->buffer_ptr + 1);
-    con->error_code= con->result->error_code;
-    /* Byte 3 is always a '#' character, skip it. */
-    memcpy(con->result->sqlstate, con->buffer_ptr + 4,
-           DRIZZLE_MAX_SQLSTATE_SIZE);
-    con->result->sqlstate[DRIZZLE_MAX_SQLSTATE_SIZE]= 0;
-    memcpy(con->sqlstate, con->result->sqlstate,
-           DRIZZLE_MAX_SQLSTATE_SIZE + 1);
-    con->buffer_ptr+= 9;
-    con->buffer_size-= 9;
-    con->packet_size-= 9;
-
-    snprintf(con->last_error, DRIZZLE_MAX_ERROR_SIZE, "%.*s",
-             (int)con->packet_size, con->buffer_ptr);
-    con->last_error[DRIZZLE_MAX_ERROR_SIZE-1]= 0;
     snprintf(con->result->info, DRIZZLE_MAX_INFO_SIZE, "%.*s",
-             (int)con->packet_size, con->buffer_ptr);
+             (int)con->packet_size, con->last_error);
     con->result->info[DRIZZLE_MAX_INFO_SIZE-1]= 0;
-    con->buffer_ptr+= con->packet_size;
-    con->buffer_size-= con->packet_size;
-    con->packet_size= 0;
 
     con->pop_state();
     con->binlog->error_fn(DRIZZLE_RETURN_ERROR_CODE, con, con->binlog->binlog_context);

--- a/libdrizzle/handshake.cc
+++ b/libdrizzle/handshake.cc
@@ -99,7 +99,11 @@ drizzle_return_t drizzle_state_handshake_server_read(drizzle_st *con)
     return DRIZZLE_RETURN_OK;
   }
 
-  if (con->packet_size < 46)
+  if (drizzle_check_unpack_error(con))
+  {
+    return DRIZZLE_RETURN_ERROR_CODE;
+  }
+  else if (con->packet_size < 46)
   {
     drizzle_set_error(con, __func__,
                       "bad packet size:>=46:%" PRIu32, con->packet_size);

--- a/libdrizzle/pack.h
+++ b/libdrizzle/pack.h
@@ -96,6 +96,17 @@ drizzle_return_t drizzle_unpack_string(drizzle_st *con, char *buffer,
 unsigned char *drizzle_pack_auth(drizzle_st *con, unsigned char *ptr,
                            drizzle_return_t *ret_ptr);
 
+/**
+ * Check if a MySQL ERR_Packet has been received, i.e. the first byte of the
+ * received packet is 0xFF.
+ * If an error packet was received the error_code and error message are set
+ *
+ * @param[in] con Drizzle structure previously initialized with
+ *  drizzle_create() or drizzle_clone().
+ * @return True if an error packet was received, false otherwise
+ */
+bool drizzle_check_unpack_error(drizzle_st *con);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/libdrizzle/result.cc
+++ b/libdrizzle/result.cc
@@ -464,19 +464,11 @@ drizzle_return_t drizzle_state_result_read(drizzle_st *con)
     con->packet_size-= 5;
     ret= DRIZZLE_RETURN_OK;
   }
-  else if (con->buffer_ptr[0] == 255)
+  else if (drizzle_check_unpack_error(con))
   {
-    con->result->error_code= drizzle_get_byte2(con->buffer_ptr + 1);
-    con->error_code= con->result->error_code;
-    /* Byte 3 is always a '#' character, skip it. */
-    memcpy(con->result->sqlstate, con->buffer_ptr + 4,
+    memcpy(con->result->sqlstate, con->sqlstate,
            DRIZZLE_MAX_SQLSTATE_SIZE);
     con->result->sqlstate[DRIZZLE_MAX_SQLSTATE_SIZE]= 0;
-    memcpy(con->sqlstate, con->result->sqlstate,
-           DRIZZLE_MAX_SQLSTATE_SIZE + 1);
-    con->buffer_ptr+= 9;
-    con->buffer_size-= 9;
-    con->packet_size-= 9;
     ret= DRIZZLE_RETURN_ERROR_CODE;
   }
   else


### PR DESCRIPTION
Check for error packet while doing handshake

If an error packet is received instead of the
expected handshake packet the function returns
DRIZZLE_RETURN_ERROR_CODE

Addresses #120
