### PR TITLE
Expand and fix string escaping capabilities

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,16 @@ SSL connections.
 New Features
 ============
 
+* `drizzle_escape_str`
+
+    This new function matches the signature of `drizzle_escape_string`, except it takes an extra parameter
+    to determine whether to escape pattern-matching characters ('%' and '_') or not.
+    Calling `drizzle_escape_string` is equivalent to calling `drizzle_escape_str` with `false` as last parameter.
+
+
+Bugs fixed
+==========
+
+- `drizzle_escape_string`
+
+    This function now correctly escapes `\b` and `\t`

--- a/libdrizzle-5.1/query.h
+++ b/libdrizzle-5.1/query.h
@@ -78,6 +78,9 @@ drizzle_result_st *drizzle_query(drizzle_st *con,
  * Escape a string for an SQL query. The to parameter is allocated by the
  * function and needs to be freed by the application when finished with.
  *
+ * This function does not escape '%' or '_', if you need to, call
+ * drizzle_escape_str with `is_pattern` set to `true`.
+ *
  * @param[in] con a connection object
  * @param[in,out] to the destination string
  * @param[in] from the source string
@@ -87,6 +90,31 @@ drizzle_result_st *drizzle_query(drizzle_st *con,
  */
 DRIZZLE_API
 ssize_t drizzle_escape_string(drizzle_st *con, char **to, const char *from, const size_t from_size);
+
+/**
+ * Escape a string for an SQL query, optionally for pattern matching.
+ *
+ * This function escapes the following characters:
+ * '\0' (0x00), '\'' (0x27), '"' (0x22), '\b' (0x08), '\n' (0x0A),
+ * '\r' (0x0D), '\t' (0x09), '\Z' (0x26), '\\' (0x5C).
+ * In case `is_pattern` is set to `true`, '%' (0x25) and '_' (0x5F)
+ * will be escaped as well.
+ *
+ * The to parameter is allocated by the function and needs to be freed by
+ * the application when finished with.
+ *
+ * @param[in] con a connection object
+ * @param[in,out] to the destination string
+ * @param[in] from the source string
+ * @param[in] from_size the length of the source string
+ * @param[in] is_pattern whether to escape '%' and '_'.
+ *                       If set to `true`, they will be escaped,
+ *                       so the string can be used in a LIKE clause for example.
+ * @return the length of the ‘to’ string or -1 upon error due to empty
+ *         parameters or overflow
+ */
+DRIZZLE_API
+ssize_t drizzle_escape_str(drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern);
 
 /** @} */
 

--- a/libdrizzle/query.cc
+++ b/libdrizzle/query.cc
@@ -57,7 +57,7 @@ drizzle_result_st *drizzle_query(drizzle_st *con,
                                    (unsigned char *)query, size, size, ret_ptr);
 }
 
-ssize_t drizzle_escape_string(drizzle_st *con, char **destination, const char *from, const size_t from_size)
+ssize_t drizzle_escape_str(drizzle_st *con, char **destination, const char *from, const size_t from_size, bool is_pattern)
 {
   (void)con;
   const char *end;
@@ -92,6 +92,12 @@ ssize_t drizzle_escape_string(drizzle_st *con, char **destination, const char *f
       case 0:
         newchar= '0';
         break;
+      case '\b':
+        newchar= 'b';
+        break;
+      case '\t':
+        newchar= 't';
+        break;
       case '\n':
         newchar= 'n';
         break;
@@ -110,6 +116,14 @@ ssize_t drizzle_escape_string(drizzle_st *con, char **destination, const char *f
       case '"':
         newchar= '"';
         break;
+      case '%':
+          if (is_pattern)
+              newchar = '%';
+          break;
+      case '_':
+          if (is_pattern)
+              newchar = '_';
+          break;
       default:
         break;
       }
@@ -144,6 +158,11 @@ ssize_t drizzle_escape_string(drizzle_st *con, char **destination, const char *f
   *to= 0;
 
   return to_size;
+}
+
+ssize_t drizzle_escape_string(drizzle_st *con, char **destination, const char *from, const size_t from_size)
+{
+    return drizzle_escape_str(con, destination, from, from_size, false);
 }
 
 bool drizzle_hex_string(char *to, const unsigned char *from, const size_t from_size)

--- a/tests/unit/escape.c
+++ b/tests/unit/escape.c
@@ -52,16 +52,33 @@ int main(int argc, char* argv[])
 
   // Test for data too long
   char *out;
-  uint64_t out_len = drizzle_escape_string(NULL, &out, in, strlen(in));
+  uint64_t out_len = drizzle_escape_str(NULL, &out, in, strlen(in), false);
   ASSERT_EQ_(17, out_len, "drizzle_escape_string(): %u != %u", 17,
              (unsigned int)(out_len));
 
   free(out);
 
-  out_len= drizzle_escape_string(NULL, &out, in, strlen(in));
+  out_len= drizzle_escape_str(NULL, &out, in, strlen(in), false);
   ASSERT_EQ_(out_len, 17, "Bad hex length output %u", (unsigned int)(out_len));
   ASSERT_EQ_(0, strcmp(out, "escape \\\"this\\\"\\n"), "Bad hex data output");
 
+  free(out);
+
+  const char *with_meta = "This will trip % LIKE _ up";
+  out_len = drizzle_escape_str(NULL, &out, with_meta, strlen(with_meta), false);
+  ASSERT_EQ_(out_len, 26, "Bad hex length output %u", (unsigned int)(out_len));
+  ASSERT_EQ_(0, strcmp(out, with_meta), "Bad hex data output");
+  free(out);
+
+  out_len = drizzle_escape_str(NULL, &out, with_meta, strlen(with_meta), true);
+  ASSERT_EQ_(out_len, 28, "Bad hex length output %u", (unsigned int)(out_len));
+  ASSERT_EQ_(0, strcmp(out, "This will trip \\% LIKE \\_ up"), "Bad hex data output");
+  free(out);
+
+  const char *tricky = "This\tis \\\\\b tricky";
+  out_len = drizzle_escape_str(NULL, &out, tricky, strlen(tricky), false);
+  ASSERT_EQ_(out_len, 22, "Bad hex length output %u", (unsigned int)(out_len));
+  ASSERT_EQ_(0, strcmp(out, "This\\tis \\\\\\\\\\b tricky"), "Bad hex data output");
   free(out);
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
The mysql manual lists 11 characters which should be escaped,
including 2 which should only escaped for string using in pattern-matching context (e.g. LIKE clause).
However, `drizzle_escape_string` was only escaping 7 characters.
As changing `drizzle_escape_string` is not an option, a new `drizzle_escape_str` is introduced
which takes an extra parameter, used as a boolean, for specifying whether the string will be
used in a pattern-matching context.