### PR TITLE
Remove reference to drizzle_clone from documentation

### DIFF
--- a/docs/api/binlog.rst
+++ b/docs/api/binlog.rst
@@ -172,6 +172,6 @@ Functions
 
    The memory (de)allocation of the filename buffer must be done by the client
 
-   :param con: Drizzle structure previously initialized with :c:func:`drizzle_create` or :c:func:`drizzle_clone`
+   :param con: Drizzle structure previously initialized with :c:func:`drizzle_create`
    :param filename: Buffer to copy filename to
    :param file_index: Index of the binlog to retrieve

--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -41,7 +41,7 @@ Functions
 
    Get file descriptor for connection.
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :returns: File descriptor of connection, or -1 if not active.
 
 .. c:function:: int drizzle_timeout(const drizzle_st *con)
@@ -84,7 +84,7 @@ Functions
 
    Set a custom I/O event watcher function for a drizzle structure
 
-   :param drizzle: Drizzle structure previously initialized with :c:func:`drizzle_create` or :c:func:`drizzle_clone`
+   :param drizzle: Drizzle structure previously initialized with :c:func:`drizzle_create`.
    :param function: Function to call when there is an I/O event, in the form of :c:func:`drizzle_event_watch_fn`
    :param context: Argument to pass into the callback function.
 
@@ -92,7 +92,7 @@ Functions
 
    Set events to be watched for a connection.
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :param events: Bitfield of poll() events to watch.
    :returns: Standard drizzle return value.
 
@@ -101,7 +101,7 @@ Functions
    Set events that are ready for a connection. This is used with the external
    event callbacks. See :c:func:`drizzle_set_event_watch_fn`.
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :param revents: Bitfield of poll() events that were detected.
    :returns: Standard drizzle return value.
 
@@ -170,7 +170,7 @@ Functions
 
       :py:const:`DRIZZLE_SOCKET_OPTION_KEEPINTVL` : The time (in seconds) between individual keepalive probes
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :param option: the option to set the value for
    :param value: the value to set
 
@@ -179,7 +179,7 @@ Functions
    Gets the value of a socket option. See :c:func:`drizzle_socket_set_options`
    for a description of the available options
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :param option: option to get the value for
    :returns: The value of the option, or -1 if the specified option doesn't exist
 
@@ -313,21 +313,21 @@ Functions
 
    Get application context pointer for a connection.
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :returns: Application context with this connection.
 
 .. c:function:: void drizzle_set_context(drizzle_st *con, void *context)
 
    Set application context pointer for a connection.
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :param context: Application context to use with this connection.
 
 .. c:function:: void drizzle_set_context_free_fn(drizzle_st *con, drizzle_context_free_fn *function)
 
    Set callback function when the context pointer should be freed.
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :param function: Function to call to clean up connection context.
 
 .. c:function:: uint8_t drizzle_protocol_version(const drizzle_st *con)
@@ -362,7 +362,7 @@ Functions
 
    Get scramble buffer for a connection.
 
-   :param con: Connection structure previously initialized with :c:func:`drizzle_create`, :c:func:`drizzle_clone`, or related functions.
+   :param con: Connection structure previously initialized with :c:func:`drizzle_create`.
    :returns: Scramble buffer for connection.
 
 .. c:function:: drizzle_capabilities_t drizzle_capabilities(const drizzle_st *con)
@@ -404,16 +404,14 @@ Functions
 
    Wait for I/O on connections.
 
-   :param drizzle: Drizzle structure previously initialized with
-                   :c:func:`drizzle_create` or :c:func:`drizzle_clone`.
+   :param drizzle: Drizzle structure previously initialized with :c:func:`drizzle_create`.
    :returns: Standard drizzle return value.
 
 .. c:function:: drizzle_st *drizzle_ready(drizzle_st *con)
 
    Get next connection that is ready for I/O.
 
-   :param drizzle: Drizzle structure previously initialized with
-                   :c:func:`drizzle_create` or :c:func:`drizzle_clone`.
+   :param drizzle: Drizzle structure previously initialized with :c:func:`drizzle_create`.
    :returns: Connection that is ready for I/O, or NULL if there are none.
 
 .. c:function:: drizzle_return_t drizzle_close(drizzle_st *con)

--- a/libdrizzle-5.1/binlog.h
+++ b/libdrizzle-5.1/binlog.h
@@ -214,8 +214,7 @@ const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_typ
  * The filename parameter is allocated by the function and needs to be
  * freed by the application when finished with.
  *
- * @param[in] con Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ * @param[in] con Drizzle structure previously initialized with drizzle_create().
  * @param[in,out] filename buffer to copy filename to
  * @param[in] file_index index of the binlog to retrieve.
  */

--- a/libdrizzle-5.1/conn.h
+++ b/libdrizzle-5.1/conn.h
@@ -56,8 +56,7 @@ extern "C" {
 /**
  * Get file descriptor for connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return File descriptor of connection, or -1 if not active.
  */
 DRIZZLE_API
@@ -66,8 +65,7 @@ int drizzle_fd(const drizzle_st *con);
 /**
  * Close a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  */
 DRIZZLE_API
 void drizzle_close(drizzle_st *con);
@@ -75,8 +73,7 @@ void drizzle_close(drizzle_st *con);
 /**
  * Set events to be watched for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[in] events Bitfield of poll() events to watch.
  * @return Standard drizzle return value.
  */
@@ -87,8 +84,7 @@ drizzle_return_t drizzle_set_events(drizzle_st *con, short events);
  * Set events that are ready for a connection. This is used with the external
  * event callbacks. See drizzle_set_event_watch_fn().
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[in] revents Bitfield of poll() events that were detected.
  * @return Standard drizzle return value.
  */
@@ -98,8 +94,7 @@ drizzle_return_t drizzle_set_revents(drizzle_st *con, short revents);
 /**
  * Return an error string for last error encountered.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Pointer to static buffer in library that holds an error string.
  */
 DRIZZLE_API
@@ -108,8 +103,7 @@ const char *drizzle_error(const drizzle_st *con);
 /**
  * Get server defined error code for the last result read.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return An error code given back in the server response.
  */
 DRIZZLE_API
@@ -118,8 +112,7 @@ uint16_t drizzle_error_code(const drizzle_st *con);
 /**
  * Get SQL state code for the last result read.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return A SQLSTATE code given back in the server response.
  */
 DRIZZLE_API
@@ -174,8 +167,7 @@ void drizzle_socket_set_options(drizzle_options_st *options, int wait_timeout,
  *  DRIZZLE_SOCKET_OPTION_KEEPINTVL : The time (in seconds) between individual
  *                                    keepalive probes
  *
- * @param[in] con Connection structure previously initialized with
- *                drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[in] option the option to set the value for
  * @param[in] value the value to set
  */
@@ -187,8 +179,7 @@ void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option,
  * Gets the value of a socket option. See drizzle_socket_set_options() for a
  * description of the available options
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[in] option option to get the value for
  * @return The value of the option, or -1 if the specified option doesn't exist
  */
@@ -325,8 +316,7 @@ drizzle_socket_owner drizzle_options_get_socket_owner(drizzle_options_st *option
 /**
  * Get TCP host for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Host this connection is configured for, or NULL if not set.
  */
 DRIZZLE_API
@@ -335,8 +325,7 @@ const char *drizzle_host(const drizzle_st *con);
 /**
  * Get TCP port for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Port this connection is configured for, 0 if not set.
  */
 DRIZZLE_API
@@ -345,8 +334,7 @@ in_port_t drizzle_port(const drizzle_st *con);
 /**
  * Get username for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return User associated with this connection.
  */
 DRIZZLE_API
@@ -355,8 +343,7 @@ const char *drizzle_user(const drizzle_st *con);
 /**
  * Get database for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Database associated with this connection.
  */
 DRIZZLE_API
@@ -365,8 +352,7 @@ const char *drizzle_db(const drizzle_st *con);
 /**
  * Get application context pointer for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Application context with this connection.
  */
 DRIZZLE_API
@@ -375,8 +361,7 @@ void *drizzle_context(const drizzle_st *con);
 /**
  * Set application context pointer for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[in] context Application context to use with this connection.
  */
 DRIZZLE_API
@@ -385,8 +370,7 @@ void drizzle_set_context(drizzle_st *con, void *context);
 /**
  * Set callback function when the context pointer should be freed.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[in] function Function to call to clean up connection context.
  */
 DRIZZLE_API
@@ -396,8 +380,7 @@ void drizzle_set_context_free_fn(drizzle_st *con,
 /**
  * Get protocol version for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Protocol version for connection.
  */
 DRIZZLE_API
@@ -406,8 +389,7 @@ uint8_t drizzle_protocol_version(const drizzle_st *con);
 /**
  * Get server version string for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Server version string for connection.
  */
 DRIZZLE_API
@@ -416,8 +398,7 @@ const char *drizzle_server_version(const drizzle_st *con);
 /**
  * Get server version number for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Server version number for connection.
  */
 DRIZZLE_API
@@ -426,8 +407,7 @@ uint32_t drizzle_server_version_number(const drizzle_st *con);
 /**
  * Get thread ID for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Thread ID for connection.
  */
 DRIZZLE_API
@@ -436,8 +416,7 @@ uint32_t drizzle_thread_id(const drizzle_st *con);
 /**
  * Get scramble buffer for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Scramble buffer for connection.
  */
 DRIZZLE_API
@@ -446,8 +425,7 @@ const unsigned char *drizzle_scramble(const drizzle_st *con);
 /**
  * Get capabilities for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Capabilities for connection.
  */
 DRIZZLE_API
@@ -456,8 +434,7 @@ drizzle_capabilities_t drizzle_capabilities(const drizzle_st *con);
 /**
  * Get character set for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Character set for connection.
  */
 DRIZZLE_API
@@ -466,8 +443,7 @@ drizzle_charset_t drizzle_charset(const drizzle_st *con);
 /**
  * Get status for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Status for connection.
  */
 DRIZZLE_API
@@ -476,8 +452,7 @@ drizzle_status_t drizzle_status(const drizzle_st *con);
 /**
  * Get max packet size for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Max packet size for connection.
  */
 DRIZZLE_API

--- a/libdrizzle-5.1/conn_client.h
+++ b/libdrizzle-5.1/conn_client.h
@@ -55,8 +55,7 @@ extern "C" {
 /**
  * Connect to server.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return Standard drizzle return value.
  */
 DRIZZLE_API
@@ -65,8 +64,7 @@ drizzle_return_t drizzle_connect(drizzle_st *con);
 /**
  * Send quit command to server for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @return ret_ptr Standard drizzle return value.
  */
 DRIZZLE_API
@@ -75,8 +73,7 @@ drizzle_return_t drizzle_quit(drizzle_st *con);
 /**
  * Select a new default database for a connection.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[in] db Default database to select.
  * @return Standard drizzle return value
  */
@@ -86,8 +83,7 @@ drizzle_return_t drizzle_select_db(drizzle_st *con, const char *db);
 /**
  * Send a shutdown message to the server.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[out] ret_ptr Standard drizzle return value.
  * @return On success, a pointer to the (possibly allocated) structure. On
  *  failure this will be NULL.
@@ -111,8 +107,7 @@ drizzle_result_st *drizzle_kill(drizzle_st *con,
 /**
  * Send a ping request to the server.
  *
- * @param[in] con Connection structure previously initialized with
- *  drizzle_create(), drizzle_clone(), or related functions.
+ * @param[in] con Connection structure previously initialized with drizzle_create().
  * @param[out] ret_ptr Standard drizzle return value.
  * @return On success, a pointer to the (possibly allocated) structure. On
  *  failure this will be NULL.

--- a/libdrizzle-5.1/drizzle.h
+++ b/libdrizzle-5.1/drizzle.h
@@ -111,8 +111,7 @@ const char *drizzle_verbose_name(drizzle_verbose_t verbose);
 /**
  * Get current socket I/O activity timeout value.
  *
- * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
  * @return Timeout in milliseconds to wait for I/O activity. A negative value
  *  means an infinite timeout.
  */
@@ -122,8 +121,7 @@ int drizzle_timeout(const drizzle_st *con);
 /**
  * Set socket I/O activity timeout for connections in a Drizzle structure.
  *
- * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
  * @param[in] timeout Milliseconds to wait for I/O activity. A negative value
  *  means an infinite timeout.
  */
@@ -134,7 +132,7 @@ void drizzle_set_timeout(drizzle_st *con, int timeout);
  * Get current verbosity threshold for logging messages.
  *
  * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ *  drizzle_create().
  * @return Current verbosity threshold.
  */
 DRIZZLE_API
@@ -146,7 +144,7 @@ drizzle_verbose_t drizzle_verbose(const drizzle_st *con);
  * messages are printed to STDOUT.
  *
  * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ *  drizzle_create().
  * @param[in] verbose Verbosity threshold of what to log.
  */
 DRIZZLE_API
@@ -157,8 +155,7 @@ void drizzle_set_verbose(drizzle_st *con, drizzle_verbose_t verbose);
  * for log messages that are above the verbosity threshold set with
  * drizzle_set_verbose().
  *
- * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
  * @param[in] function Function to call when there is a logging message.
  * @param[in] context Argument to pass into the callback function.
  */
@@ -177,8 +174,7 @@ void drizzle_set_log_fn(drizzle_st *con, drizzle_log_fn *function,
  * interested. To resume processing, the libdrizzle function that returned
  * DRIZZLE_RETURN_IO_WAIT should be called again. See drizzle_event_watch_fn().
  *
- * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
  * @param[in] function Function to call when there is an I/O event.
  * @param[in] context Argument to pass into the callback function.
  */
@@ -191,8 +187,7 @@ void drizzle_set_event_watch_fn(drizzle_st *drizzle,
 /**
  * Wait for I/O on connections.
  *
- * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
  * @return Standard drizzle return value.
  */
 DRIZZLE_API
@@ -201,8 +196,7 @@ drizzle_return_t drizzle_wait(drizzle_st *con);
 /**
  * Get next connection that is ready for I/O.
  *
- * @param[in] drizzle Drizzle structure previously initialized with
- *  drizzle_create() or drizzle_clone().
+ * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
  * @return Connection that is ready for I/O, or NULL if there are none.
  */
 DRIZZLE_API


### PR DESCRIPTION
`drizzle_clone` was removed from the public API at an
earlier point but it wasn't reflected in the
documentation

The mention is removed from rst api docs and function
documentation in header files.