### PR TITLE
Rename and deprecate drizzle_socket_option and drizzle_socket_owner

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -155,7 +155,7 @@ Functions
    :param keepcnt: The maximum number of keepalive probes TCP should send before dropping the connection.
    :param keepintvl: The time (in seconds) between individual keepalive probes
 
-.. c:function:: void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option, int value)
+.. c:function:: void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option_t option, int value)
 
    Sets the value of a socket option.
 
@@ -174,7 +174,7 @@ Functions
    :param option: the option to set the value for
    :param value: the value to set
 
-.. c:function:: int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option option)
+.. c:function:: int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option)
 
    Gets the value of a socket option. See :c:func:`drizzle_socket_set_options`
    for a description of the available options

--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -267,14 +267,14 @@ Functions
    :param options: The options object to get the value from
    :returns: The state of the auth plugin option
 
-.. c:function:: void drizzle_options_set_socket_owner(drizzle_options_st *options, drizzle_socket_owner owner)
+.. c:function:: void drizzle_options_set_socket_owner(drizzle_options_st *options, drizzle_socket_owner_t owner)
 
    Sets the owner of the socket connection
 
    :param options: The options object to modify
    :param owner: The owner of the socket connection
 
-.. c:function:: drizzle_socket_owner drizzle_options_get_socket_owner(drizzle_options_st *options)
+.. c:function:: drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options)
 
    Gets the owner of the socket connection
 

--- a/docs/api/constants.rst
+++ b/docs/api/constants.rst
@@ -741,7 +741,7 @@ Connection
 
       SSL connection is established
 
-.. c:type:: drizzle_socket_owner
+.. c:type:: drizzle_socket_owner_t
 
    Owner of socket connection
 

--- a/libdrizzle-5.1/conn.h
+++ b/libdrizzle-5.1/conn.h
@@ -302,7 +302,7 @@ bool drizzle_options_get_auth_plugin(drizzle_options_st *options);
  */
 DRIZZLE_API
 void drizzle_options_set_socket_owner(drizzle_options_st *options,
-                                      drizzle_socket_owner owner);
+                                      drizzle_socket_owner_t owner);
 
 /**
  * Gets the owner of the socket connection
@@ -311,7 +311,7 @@ void drizzle_options_set_socket_owner(drizzle_options_st *options,
  * @return The owner of the socket
  */
 DRIZZLE_API
-drizzle_socket_owner drizzle_options_get_socket_owner(drizzle_options_st *options);
+drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options);
 
 /**
  * Get TCP host for a connection.

--- a/libdrizzle-5.1/conn.h
+++ b/libdrizzle-5.1/conn.h
@@ -172,7 +172,7 @@ void drizzle_socket_set_options(drizzle_options_st *options, int wait_timeout,
  * @param[in] value the value to set
  */
 DRIZZLE_API
-void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option,
+void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option_t option,
                                int value);
 
 /**
@@ -184,7 +184,7 @@ void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option,
  * @return The value of the option, or -1 if the specified option doesn't exist
  */
 DRIZZLE_API
-int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option option);
+int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option);
 
 /**
  * Sets/unsets non-blocking connect option

--- a/libdrizzle-5.1/constants.h
+++ b/libdrizzle-5.1/constants.h
@@ -303,7 +303,9 @@ typedef enum
   DRIZZLE_SOCKET_OPTION_KEEPCNT,
   DRIZZLE_SOCKET_OPTION_KEEPINTVL,
   DRIZZLE_SOCKET_OPTION_TIMEOUT
-} drizzle_socket_option;
+} drizzle_socket_option_t;
+
+typedef drizzle_socket_option_t drizzle_socket_option __attribute__ ((deprecated));
 
 typedef enum
 {

--- a/libdrizzle-5.1/constants.h
+++ b/libdrizzle-5.1/constants.h
@@ -289,7 +289,9 @@ typedef enum
 {
   DRIZZLE_SOCKET_OWNER_NATIVE=0,
   DRIZZLE_SOCKET_OWNER_CLIENT
-} drizzle_socket_owner;
+} drizzle_socket_owner_t;
+
+typedef drizzle_socket_owner_t drizzle_socket_owner __attribute__ ((deprecated));
 
 /**
  * @ingroup drizzle_con

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -233,7 +233,7 @@ void drizzle_socket_set_options(drizzle_options_st *options, int wait_timeout,
   options->keepintvl = keepintvl;
 }
 
-void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option,
+void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option_t option,
   int value)
 {
   if (con == NULL)
@@ -264,7 +264,7 @@ void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option option,
   }
 }
 
-int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option option)
+int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option)
 {
   if (con == NULL)
   {

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -399,7 +399,7 @@ bool drizzle_options_get_auth_plugin(drizzle_options_st *options)
 }
 
 void drizzle_options_set_socket_owner(drizzle_options_st *options,
-                   drizzle_socket_owner owner)
+                   drizzle_socket_owner_t owner)
 {
   if (options == NULL)
   {
@@ -408,7 +408,7 @@ void drizzle_options_set_socket_owner(drizzle_options_st *options,
   options->socket_owner = owner;
 }
 
-drizzle_socket_owner drizzle_options_get_socket_owner(drizzle_options_st *options)
+drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options)
 {
   if (options == NULL)
   {

--- a/libdrizzle/structs.h
+++ b/libdrizzle/structs.h
@@ -159,7 +159,7 @@ struct drizzle_options_st
   bool interactive;
   bool multi_statements;
   bool auth_plugin;
-  drizzle_socket_owner socket_owner;
+  drizzle_socket_owner_t socket_owner;
   int wait_timeout;
   int keepidle;  // default value under linux: 7200
   int keepcnt;   // default value under linux: 75


### PR DESCRIPTION
Make drizzle_socket_option and drizzle_socket_owner
comply with the naming convention for enums by adding a 
suffix `_t`. 

The old names are still exported but have been deprecated  
