### PR TITLE
Fix epub doc configuration

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,9 +4,9 @@
     <div class="footer">
     {%- if show_copyright %}
       {%- if hasdoc('copyright') %}
-        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&#169; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
       {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+        {% trans copyright=copyright|e %}&#169; Copyright {{ copyright }}.{% endtrans %}
       {%- endif %}
     {%- endif %}
     {%- if last_updated %}
@@ -16,7 +16,7 @@
       {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
     {%- endif %}
     <br />
-       <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons Licence" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/3.0/80x15.png" /></a>&nbsp;This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.
+       <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons Licence" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/3.0/80x15.png" /></a>&#160;This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.
     </div>
 {%- endblock %}
 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -222,6 +222,8 @@ latex_elements = {
     'classoptions': 'openany,oneside', 'babel' : '\\usepackage[english]{babel}'
 }
 
+epub_exclude_files = ['.doctrees/compiling.doctree', '.doctrees/examples/statement.doctree']
+
 # -- Options for manual page output --------------------------------------------
 
 ##


### PR DESCRIPTION
Some characters were written as html entity names.
Those characters are &nbsp; and &copy have been
encoded with their equivalent html entity number

Files not relevant for the epub build have been
excluded as well using the 'epub_exclude_files'
setting.