### PR TITLE
Change the location of the output from automake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,11 @@
 aclocal.m4
 aminclude.am
 autom4te.cache/
+build/
 build-aux/
 config.h
 config.in
 configure
-deb/install
 .deps
 docs/conf.py
 src/.*

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,28 +48,24 @@ EXTRA_DIST+= COPYING
 
 # Cleanup individual files in order to preserve uninstall/etc order
 maintainer-clean-local:
-	-rm Makefile.in
-	-rm aclocal.m4
-	-rm build-aux/compile
-	-rm build-aux/config.guess
-	-rm build-aux/config.sub
-	-rm build-aux/depcomp
-	-rm build-aux/install-sh
-	-rm build-aux/ltmain.sh
-	-rm build-aux/missing
-	-rmdir build-aux
-	-rm configure
-	-rm config.log
-	-rm config.status
-	-rm config.in
-	-rm m4/libtool.m4
-	-rm m4/ltoptions.m4
-	-rm m4/ltsugar.m4
-	-rm m4/ltversion.m4
-	-rm m4/lt~obsolete.m4
-	find . -type f -name '*~' -exec rm -f '{}' \;
-	-rm -f @PACKAGE@-*.tar.gz
-	-rm -f ./pkg/rpm/@PACKAGE@-*.rpm
-	-rm -f ./pkg/deb/@PACKAGE@-*.deb
+	cd @abs_top_srcdir@; \
+	rm Makefile.in; \
+	rm aclocal.m4; \
+	rm configure; \
+	rm config.in; \
+	rm m4/libtool.m4; \
+	rm m4/ltoptions.m4; \
+	rm m4/ltsugar.m4; \
+	rm m4/ltversion.m4; \
+	rm m4/lt~obsolete.m4; \
+	find . -type f -name '*~' -exec rm -f '{}' \; ; \
+	cd @abs_builddir@; \
+	rm -rf build-aux; \
+	rm config.log; \
+	rm config.status; \
+	rm -f @PACKAGE@-*.tar.gz; \
+	rm -f ./pkg/rpm/@PACKAGE@-*.rpm; \
+	rm -f ./pkg/deb/@PACKAGE@-*.deb; \
+	rm -rf pkg/deb/install
 
 dist_bin_SCRIPTS+= @GENERIC_CONFIG@

--- a/README.rst
+++ b/README.rst
@@ -109,8 +109,9 @@ To build **libdrizzle-redux** you can invoke bootstrap script::
 
 Alternatively you can build and customize::
 
-    autoreconf -fi
-    ./configure
+    mkdir build && cd build
+    autoreconf -fi ..
+    ../configure
     make
     make install
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,5 +12,17 @@ openssl<sup>1</sup> | >=v1.x
 <sup>1</sup> openssl is needed if libdrizzle-redux is compiled with support for
 SSL connections.
 
+Migration Notes
+===============
+
+The library is now built in a separate toplevel directory `build`.
+The modified build process is as follows:
+
+    mkdir build && cd build
+    autoreconf -fi ..
+    ../configure
+    make
+    make install
+
 New Features
 ============

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 
 AC_INIT([libdrizzle-redux6],[6.0.7],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux6],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
 
-AC_CONFIG_AUX_DIR([build-aux])
+AC_CONFIG_AUX_DIR([build/build-aux])
 
 AC_CANONICAL_TARGET
 
@@ -147,8 +147,8 @@ AX_HEX_VERSION([LIBDRIZZLE],[$VERSION])
 AX_HARDEN_COMPILER_FLAGS
 
 # Append the -./Iinclude to compiler flags
-AX_APPEND_COMPILE_FLAGS([-I./include], [CXXFLAGS])
-AX_APPEND_COMPILE_FLAGS([-I./include], [CFLAGS])
+AX_APPEND_COMPILE_FLAGS([-I$srcdir/include -I$srcdir -I./ -I./include], [CXXFLAGS])
+AX_APPEND_COMPILE_FLAGS([-I$srcdir/include -I$srcdir -I./ -I./include], [CFLAGS])
 
 AX_CREATE_GENERIC_CONFIG
 AX_AM_JOBSERVER([yes])
@@ -156,8 +156,9 @@ AX_AM_JOBSERVER([yes])
 AC_CONFIG_FILES([Makefile
                  docs/conf.py
                  pkg/rpm/spec
-                 include/libdrizzle-redux/version.h
+                 include/libdrizzle-redux/version.h:$srcdir/include/libdrizzle-redux/version.h.in
                  ])
+AC_CONFIG_FILES([pkg/deb/build:$srcdir/pkg/deb/build],[chmod +x pkg/deb/build])
 
 AC_OUTPUT
 

--- a/docker/container_entrypoint.sh
+++ b/docker/container_entrypoint.sh
@@ -22,14 +22,19 @@ install_dependencies()
 }
 
 # install dependencies
-#chmod +x /usr/local/bin/install_dependencies.sh
 install_dependencies
 
 # configure and compile the project
 # run make targets specified in env MAKE_TARGET
-if [[ ! -e ./configure ]]; then
-    autoreconf -fi
-    ./configure
+if [[ ! -d ./build ]]; then
+    mkdir build
+fi
+
+cd build
+
+if [[ ! -e ../configure ]]; then
+    autoreconf -fi ..
+    ../configure
 fi
 
 make ${MAKE_TARGET//:/ }

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -42,8 +42,9 @@ To build libdrizzle-redux you can invoke bootstrap script::
 
 Alternatively you can build and customize::
 
-   autoreconf -fi
-   ./configure
+   mkdir build && cd build
+   autoreconf -fi ..
+   ../configure
    make
    make install
 

--- a/docs/include.am
+++ b/docs/include.am
@@ -7,85 +7,89 @@
 
 SPHINXOPTS    = ${SPHINX_WARNINGS} -q
 PAPER         =
-SPHINX_SOURCEDIR = ${abs_srcdir}/docs
-SPHINX_BUILDDIR  = ${abs_srcdir}/sphinx-build
+SPHINX_SOURCEDIR = ${abs_top_srcdir}/docs
+SPHINX_BUILDDIR = ${abs_builddir}/docs
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -c $(top_builddir)/docs $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SPHINX_SOURCEDIR)
+ALLSPHINXOPTS   = -c $(SPHINX_BUILDDIR) $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SPHINX_SOURCEDIR)
 
 .PHONY: clean-docs-check
 clean-docs-check:
-	-rm -rf $(SPHINX_BUILDDIR)/_build $(SPHINX_BUILDDIR)/doctrees
+	-rm -rf $(SPHINX_BUILDDIR)/doctrees
 
 .PHONY: clean-docs-all
 clean-docs-all: clean-docs-check
 	-rm -rf $(SPHINX_BUILDDIR)
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest copysource
 
-man: docs/conf.py
-	@PYTHONPATH=$(top_builddir)/docs  $(SPHINXBUILD) -b man $(ALLSPHINXOPTS) ${SPHINX_BUILDDIR}/man
+copysource: docs/conf.py
+	@$(MKDIR_P) $(SPHINX_SOURCEDIR)
+	@cp -rf $(SPHINX_SOURCEDIR)/_static $(SPHINX_SOURCEDIR)/_templates $(SPHINX_BUILDDIR)/
+
+man: copysource
+	@PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b man $(ALLSPHINXOPTS) ${SPHINX_BUILDDIR}/man
 
 install-html-local: html-local
-	@$(MKDIR_P)  $(htmldir)/html
+	@$(MKDIR_P) $(htmldir)/html
 	@cp -r ${top_builddir}/html $(htmldir)/
 
-html-local: docs/conf.py
-	@PYTHONPATH=${top_srcdir}/docs $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) ${SPHINX_BUILDDIR}/html
+html-local: copysource
+	@PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) ${SPHINX_BUILDDIR}/html
 
 singlehtml: html-local
-	@PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/singlehtml
+	@PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/singlehtml
 
-pickle: docs/conf.py
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/pickle
+pickle: copysource
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json: docs/conf.py
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/json
+json: copysource
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp: docs/conf.py
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/htmlhelp
+htmlhelp: copysource
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(SPHINX_BUILDDIR)/htmlhelp."
 
-epub: docs/conf.py
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/epub
+epub: copysource
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -v  -b epub $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(SPHINX_BUILDDIR)/epub."
 
 latex-package-check: latex
-	docs/latex_check_packages.sh
+	$(SPHINX_SOURCEDIR)/latex_check_packages.sh
 
-latex: docs/conf.py
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/latex
+latex: copysource
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(SPHINX_BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
 latexpdf: latex
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/latex
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/LaTeX
 	@echo "Running LaTeX files through pdflatex..."
 	make -C $(SPHINX_BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(SPHINX_BUILDDIR)/latex."
 
-text: docs/conf.py
-	@PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/text
+text: copysource
+	@PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/text
 
-changes: docs/conf.py
-	@PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/changes
+changes: copysource
+	@PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/changes
 
-linkcheck: docs/conf.py
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/linkcheck
+linkcheck: copysource
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/linkcheck
 
 # Requires adding "sphinx.ext.doctest" to "extensions" in conf.py.in
-doctest: docs/conf.py
-	PYTHONPATH=${top_srcdir}/docs  $(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/doctest
+doctest: copysource
+	PYTHONPATH=$(SPHINX_SOURCEDIR) $(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(SPHINX_BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(SPHINX_BUILDDIR)/doctest/output.txt."

--- a/include/libdrizzle-redux/include.am
+++ b/include/libdrizzle-redux/include.am
@@ -24,3 +24,5 @@ nobase_include_HEADERS+= include/libdrizzle-redux/structs.h
 nobase_include_HEADERS+= include/libdrizzle-redux/verbose.h
 nobase_include_HEADERS+= include/libdrizzle-redux/visibility.h
 nobase_include_HEADERS+= include/libdrizzle-redux/version.h
+
+EXTRA_DIST+=include/libdrizzle-redux/version.h.in

--- a/pkg/deb/include.am
+++ b/pkg/deb/include.am
@@ -4,10 +4,12 @@
 #
 # Makefile for building deb package
 
+EXTRA_DIST+=pkg/deb/build
+
 .PHONY: clean-deb deb install-deb release-deb
 
 deb: clean-deb
-	./configure --prefix=/usr
+	${abs_top_srcdir}/configure --prefix=/usr --srcdir=${abs_top_srcdir}
 	$(MAKE) DESTDIR=${abs_builddir}/pkg/deb/install install
 	pkg/deb/build $(PACKAGE)
 
@@ -23,4 +25,4 @@ release-deb:
 	git tag -a -m "$$msg" $$version
 
 clean-deb:
-	-rm -rf pkg/deb/*.deb pkg/deb/install
+	-rm -rf ${abs_builddir}/pkg/deb/*.deb ${abs_builddir}/pkg/deb/install

--- a/tests/unit/include.am
+++ b/tests/unit/include.am
@@ -9,6 +9,7 @@ noinst_HEADERS+= tests/unit/common.h
 
 tests_unit_binlog_SOURCES= tests/unit/binlog.c tests/unit/common.c
 tests_unit_binlog_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
+nodist_EXTRA_tests_unit_binlog_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/binlog
 noinst_PROGRAMS+= tests/unit/binlog
 
@@ -99,6 +100,7 @@ noinst_PROGRAMS+= tests/unit/version
 
 tests_unit_version_cxx_SOURCES= tests/unit/version_cxx.cc
 tests_unit_version_cxx_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
+nodist_EXTRA_tests_unit_version_cxx_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/version_cxx
 noinst_PROGRAMS+= tests/unit/version_cxx
 


### PR DESCRIPTION
Sanitize the build output so files generated by make
are written to a separate toplevel dir 'build'

Update instructions for building in a separate dir