### PR TITLE
drizzle_row_buffer(): clear 'result->field_sizes' before buffering fi…

### DIFF
--- a/libdrizzle/row.cc
+++ b/libdrizzle/row.cc
@@ -126,6 +126,7 @@ drizzle_row_t drizzle_row_buffer(drizzle_result_st *result,
     return NULL;
   }
 
+  memset(result->field_sizes, 0, sizeof(size_t) * result->column_count);
   while (1)
   {
     field= drizzle_field_buffer(result, &total, ret_ptr);


### PR DESCRIPTION
In src/row.cc:121

```cpp
  if (result->row == NULL)
  {
    drizzle_set_error(result->con, __func__, "Failed to allocate.");
    *ret_ptr= DRIZZLE_RETURN_MEMORY;
    return NULL;
  }

  result->field_sizes= new (std::nothrow) size_t[result->column_count]; // HERE
  if (result->field_sizes == NULL)
  {
    drizzle_set_error(result->con, __func__, "Failed to allocate.");
    *ret_ptr= DRIZZLE_RETURN_MEMORY;
    return NULL;
  }
```

After allocated the "field_sizes" buffer, it's uninitialized ("size_t" is essentially "unsigned long" and has no constructors, thus not initialized by compiler), and "drizzle_field_buffer" may give less columns than "result->column_count" since NULL fields are not buffered.

So the last few elements of "result->field_sizes" may be some ramdom garbage.

Later this value is being used to create column buffers in result.cc:381
```cpp
    for (x= 0; x < result->column_count; x++)
    {
      if (result->field_sizes[x] > 0)
      {
        result->row_list[result->row_current - 1][x]= new char[result->field_sizes[x]+1](); // HERE
        memcpy(result->row_list[result->row_current - 1][x], row[x], result->field_sizes[x]);
      }
    }
```

Which may cause serious problems.

This patch added "memset()" after allocating memory and checking for null pointer to initialize the "field_sizes" array.

(Reference #144)