### PR TITLE
Bump version to v5.5.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,31 @@ AC_CONFIG_HEADERS([config.h:config.in])dnl Keep filename to 8.3 for MS-DOS.
 
 AC_CONFIG_SRCDIR([libdrizzle/drizzle.cc])
 
-#shared library versioning
+# Shared library versioning
+#
+# The following explanation considers library changes and ABI compatibility from
+# the users' perspective and how they relate to the shared library version.(§)
+#
+# Programs using the previous version may use the new version as drop-in
+# replacement, and programs using the new version can also work with the
+# previous one. In other words, no recompiling nor relinking is needed.
+# In this case:
+#     bump revision only, don’t touch current nor age.
+#
+# Programs using the previous version may use the new version as drop-in
+# replacement, but programs using the new version may use APIs not present in
+# the previous one. In other words, a program linking against the new version
+# may fail with “unresolved symbols” if linking against the old version at
+# runtime. In this case:
+#     set revision to 0, bump current and age.
+#
+# Programs may need to be changed, recompiled, relinked in order to use the
+# new version:
+#     bump current, set revision and age to 0.
+#
+# (§) The explanation is taken from this blogpost:
+# http://blog.asleson.org/index.php/2014/07/08/libtool-library-versioning-version-info-currentrevisionage/
+#
 LIBDRIZZLE_LIBRARY_VERSION=11:1:1
 #                         | | |
 #                  +------+ | +---+
@@ -37,7 +61,8 @@ LIBDRIZZLE_LIBRARY_VERSION=11:1:1
 #                 current:revision:age
 #                  |        |     |
 #                  |        |     +- increment if interfaces have been added
-#                  |        |        set to zero if interfaces have been removed or changed
+#                  |        |        set to zero if interfaces have been removed
+#                                    or changed
 #                  |        +- increment if source code has changed
 #                  |           set to zero if current is incremented
 #                  +- increment if interfaces have been added, removed or changed

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 # Use and distribution licensed under the BSD license.  See
 # the COPYING file in this directory for full text.
 
-AC_INIT([libdrizzle-redux],[5.5.1],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
+AC_INIT([libdrizzle-redux],[5.5.2],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -54,7 +54,7 @@ AC_CONFIG_SRCDIR([libdrizzle/drizzle.cc])
 # (§) The explanation is taken from this blogpost:
 # http://blog.asleson.org/index.php/2014/07/08/libtool-library-versioning-version-info-currentrevisionage/
 #
-LIBDRIZZLE_LIBRARY_VERSION=11:1:1
+LIBDRIZZLE_LIBRARY_VERSION=11:2:1
 #                         | | |
 #                  +------+ | +---+
 #                  |        |     |

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -84,6 +84,13 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/libdrizzle-5.1/visibility.h
 
 %changelog
+* Wed Apr 12 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> - 5.5.2
+- Improve error message for latex package check
+- Fix epub doc configuration
+- Bugfix: clear "result->field_sizes" before buffering fields
+- Improve documentation for ABI versioning
+- Documentation available at libdrizle-redux.readthedocs.io
+
 * Fri Mar 24 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> - 5.5.1
 - Minor fixes
 - Add missing API functions to the rst documentation


### PR DESCRIPTION
New ABI version is 10.1.2

Update changelog for rpm spec file