### PR TITLE
Add the major version of the release as suffix to the package name

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ CLEANFILES =
 DISTCLEANFILES =
 bin_PROGRAMS =
 dist_bin_SCRIPTS =
+distdir = @PACKAGE@@API_LEVEL@-@VERSION@
 noinst_HEADERS =
 lib_LTLIBRARIES =
 man_MANS =
@@ -69,8 +70,8 @@ maintainer-clean-local:
 	-rm m4/ltversion.m4
 	-rm m4/lt~obsolete.m4
 	find . -type f -name '*~' -exec rm -f '{}' \;
-	-rm -f @PACKAGE@-*.tar.gz
-	-rm -f rpm/@PACKAGE@-*.rpm
-	-rm -f @PACKAGE@-*.deb
+	-rm -f @PACKAGE@@API_LEVEL@-*.tar.gz
+	-rm -f rpm/@PACKAGE@@API_LEVEL@-*.rpm
+	-rm -f @PACKAGE@@API_LEVEL@-*.deb
 
 dist_bin_SCRIPTS+= @GENERIC_CONFIG@

--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,20 @@ refer to `compiling.rst`_ or build the documentation, cf. below.
 
 **Linking libdrizzle-redux**::
 
+Ensure the library is in your library and include paths. For releases prior to
+version ``v6.0.2`` linking your app against libdrizzle-redux requires the flag
+``-ldrizzle-redux``::
+
     g++ app.c -oapp -ldrizzle-redux -lssl -lcrypto -pthread
 
-If **libdrizzle-redux** is installed alongside other versions of libdrizzle,
-the linking should be done with the full name of the dynamic library, e.g.::
+From version ``v6.0.2`` and later the API level of the library is appended to
+the installed library name. Thus, linking against ``libdrizzle-redux v6.0.2``
+requires the flag ``-ldrizzle-redux6``::
+
+    g++ app.c -oapp -ldrizzle-redux6 -lssl -lcrypto -pthread
+
+Another option is to link against libdrizzle-redux using the full name of the
+dynamic library, e.g.::
 
     g++ app.c -oapp -l:libdrizzle-redux.so.9 -lssl -lcrypto -pthread
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,12 @@ AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE(1.11 no-define color-tests -Wno-portability subdir-objects foreign tar-ustar m4_ifndef([AM_WITH_REGEX], [serial-tests]))
 AC_PREREQ([2.68])
 
+# Define the api level of the package.
+AC_SUBST([API_LEVEL],[6])
+
+# Add the api level to the name of the generated tar file
+AC_SUBST([PACKAGE_TARNAME],[$PACKAGE_NAME$API_LEVEL])
+
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 AC_ARG_PROGRAM

--- a/deb/build
+++ b/deb/build
@@ -2,6 +2,14 @@
 #
 # script using fpm <https://github.com/jordansissel/fpm> to build libdrizzle-redux
 # runtime, debugging and development deb packages
+#
+# Usage: ./build [api_level]
+#
+#     api_level        the api level for the package
+#
+# The `api_level` will be appended to the `package_name` for the generated
+# packages, i.e. running `./build 6` would generate a packages named
+# `libdrizzle-redux6`, `libdrizzle-redux6-dbg`, `libdrizzle-redux6-dev`.
 
 set -e
 
@@ -32,10 +40,27 @@ pkgmaint=$(echo "`git config user.name` <`git config user.email`>")
 
 # package name
 pkgname=libdrizzle-redux
-so_filename=libdrizzle-redux.so
 
-version_number=`find ./install/usr/lib/ ! -type l -name "$so_filename.*"`
+# library .so name
+so_libname=$pkgname.so
 
+# get the api level for the package from the cmd args
+api_level=""
+if [ $# -eq 1 -a ! -z "$1" ]; then
+    api_level=$1
+fi
+
+# the package name used in the distribution
+dist_pkgname=$pkgname$api_level
+
+# the so library name used in the distribution
+dist_so_libname=$dist_pkgname.so
+
+# relative path to the directory with library files to install
+libdir="./install/usr/lib"
+
+# get the ABI library version from the generated .so file
+version_number=`find $libdir ! -type l -name "$so_libname.*"`
 if [ ! -e $version_number ]; then
     echo "'.so' file not found"
     exit 1
@@ -44,15 +69,29 @@ fi
 libversion=`echo $version_number | grep -o -P -e "([0-9]+\.?)+$"`
 lib_major=$(echo $libversion | cut -f1 -d .)
 
+# create temp file to write changelog to
 changelog=`mktemp`
 trap "rm -f '$changelog'; exit 1" INT TERM QUIT
 
-so_libname="./install/usr/lib/$so_filename"
+# (re)create symbolic links with the distributed package name, dist_pkgname
+cd $libdir
+touch $dist_so_libname.$libversion
+ln -sf $dist_so_libname.$libversion $dist_so_libname.$lib_major
+ln -sf $dist_so_libname.$lib_major $dist_so_libname
+cd -
 
-genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
+# prepend the relative file path to so_libname
+so_libname="$libdir/$so_libname"
+
+# create a copy of the library file
 cp $so_libname.$libversion $so_libname.$libversion.full
-strip  $so_libname.$libversion
-fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
+
+# strip symbols from the library file
+strip $so_libname.$libversion
+
+# libdrizzle-redux runtime package
+genchangelog "$dist_pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
+fpm -s dir -t deb -n "$dist_pkgname" -v "$pkgversion" \
     --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
@@ -66,16 +105,16 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
     --depends libgcc1 \
     --deb-changelog "$changelog" \
     --deb-no-default-config-files \
-    $so_libname.$libversion=/usr/lib/ \
-    $so_libname.$lib_major=/usr/lib/
+    $so_libname.$libversion=/usr/lib/$dist_pkgname.so.$libversion \
+    $libdir/$dist_so_libname.$lib_major=/usr/lib/
 
-pkgname=libdrizzle-redux-dbg
-genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
-build_id=`readelf -n install/usr/lib/libdrizzle-redux.so.$libversion | \
+# libdrizzle-redux debug package
+genchangelog "$dist_pkgname-dbg" "$pkgversion" "$pkgmaint" > "$changelog"
+build_id=`readelf -n $so_libname.$libversion | \
     sed -n 's/^.*Build ID: \([a-f0-9]\{40\}\).*$/\1/p'`
 debug_file=`printf $build_id | cut -b1-2`/`printf $build_id | cut -b3-`.debug
 objcopy --only-keep-debug $so_libname.$libversion.full $so_libname.$libversion.debug
-fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
+fpm -s dir -t deb -n "$dist_pkgname-dbg" -v "$pkgversion" \
     --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
@@ -83,14 +122,14 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
     --vendor 'Sociomantic Labs GmbH' \
     --license 'Simplified BSD License' \
     --category debug \
-    --depends libdrizzle-redux \
+    --depends $dist_pkgname \
     --deb-changelog "$changelog" \
     --deb-no-default-config-files \
     $so_libname.$libversion.debug=/usr/lib/debug/.build-id/$debug_file
 
-pkgname=libdrizzle-redux-dev
-genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
-fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
+# libdrizzle-redux development package
+genchangelog "$dist_pkgname-dev" "$pkgversion" "$pkgmaint" > "$changelog"
+fpm -s dir -t deb -n "$dist_pkgname-dev" -v "$pkgversion" \
     --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
@@ -98,9 +137,9 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
     --vendor 'Sociomantic Labs GmbH' \
     --license 'Simplified BSD License' \
     --category libdevel \
-    --depends libdrizzle-redux \
+    --depends $dist_pkgname \
     --deb-changelog "$changelog" \
     --deb-no-default-config-files \
-    install/usr/include/=/usr/ \
-    $so_libname=/usr/lib/ \
-    install/usr/lib/libdrizzle-redux.a=/usr/lib/
+    install/usr/include/include/=/usr/include/$pkgname/$dist_pkgname/ \
+    $libdir/$dist_so_libname=/usr/lib/ \
+    $libdir/$pkgname.a=/usr/lib/$dist_pkgname.a

--- a/deb/build
+++ b/deb/build
@@ -1,8 +1,14 @@
 #!/bin/sh
+#
+# script using fpm <https://github.com/jordansissel/fpm> to build libdrizzle-redux
+# runtime, debugging and development deb packages
+
 set -e
 
+# cd to the directory containing the deb `build` script
 cd `dirname $0`
 
+# function to automatically generate changelog
 genchangelog()
 {
     echo "$1 ($2) `lsb_release -sc`; urgency=low"
@@ -14,28 +20,29 @@ genchangelog()
     echo " -- $3  `LANG=C date -R`"
 }
 
+# generate package version from `git describe` and `lsb_release` info
 pkgversion=$(git describe --dirty | cut -c2- |
              sed 's/-\([0-9]\+\)-\(g[0-9a-f]\+\)/+\1~\2/' |
              sed 's/\(~g[0-9a-f]\+\)-dirty$/-dirty\1/' |
              sed 's/-dirty/~dirty.'`date +%Y%m%d%H%M%S`'/'
             )-$(lsb_release -cs)
 
+# get package maintainer info
 pkgmaint=$(echo "`git config user.name` <`git config user.email`>")
 
+# package name
 pkgname=libdrizzle-redux
 so_filename=libdrizzle-redux.so
 
 version_number=`find ./install/usr/lib/ ! -type l -name "$so_filename.*"`
 
-if [ $(echo $version_number | wc -l) != 1 ]; then
+if [ ! -e $version_number ]; then
     echo "'.so' file not found"
     exit 1
 fi
 
 libversion=`echo $version_number | grep -o -P -e "([0-9]+\.?)+$"`
 lib_major=$(echo $libversion | cut -f1 -d .)
-lib_minor=$(echo $libversion | cut -f2 -d .)
-lib_patch=$(echo $libversion | cut -f3 -d .)
 
 changelog=`mktemp`
 trap "rm -f '$changelog'; exit 1" INT TERM QUIT

--- a/deb/include.am
+++ b/deb/include.am
@@ -9,7 +9,7 @@
 deb: clean-deb
 	./configure --prefix=/usr
 	$(MAKE) DESTDIR=${abs_builddir}/deb/install install
-	deb/build
+	deb/build $(API_LEVEL)
 
 release-deb:
 	@read -p "Enter version (previous: $$(git describe --abbrev=0)): " version; \

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -84,10 +84,17 @@ The test suite can be run in wine, to do this follow these steps:
 Linking Your Application
 ------------------------
 
-To link your app to libdrizzle-redux you need to provide the following to GCC,
-this assumes that the library is in your library and include paths::
+Ensure the library is in your library and include paths. For releases prior to
+version ``v6.0.2`` linking your app against libdrizzle-redux requires the flag
+``-ldrizzle-redux``::
 
-   gcc app.c -oapp -ldrizzle-redux -lpthread
+    g++ app.c -oapp -ldrizzle-redux -lssl -lcrypto -pthread
+
+From version ``v6.0.2`` and later the API level of the library is appended to
+the installed library name. Thus, linking against ``libdrizzle-redux v6.0.2``
+requires the flag ``-ldrizzle-redux6``::
+
+    g++ app.c -oapp -ldrizzle-redux6 -lssl -lcrypto -pthread
 
 A tool called **libdrizzle-redux_config** is included to also assist with this.
 

--- a/rpm/include.am
+++ b/rpm/include.am
@@ -2,8 +2,8 @@
 
 rpm-build: rpm/spec dist
 	@rm -f *.rpm
-	@rm -f ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-$(VERSION)*.rpm
-	@rm -f ~/rpmbuild/SRPMS/$(PACKAGE)-$(VERSION)*.rpm
+	@rm -f ~/rpmbuild/RPMS/x86_64/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm
+	@rm -f ~/rpmbuild/SRPMS/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm
 	@mkdir -p ~/rpmbuild/BUILD/
 	@mkdir -p ~/rpmbuild/RPMS/i386/
 	@mkdir -p ~/rpmbuild/RPMS/i686/
@@ -12,11 +12,11 @@ rpm-build: rpm/spec dist
 	@mkdir -p ~/rpmbuild/SOURCES/
 	@mkdir -p ~/rpmbuild/SPECS/
 	@mkdir -p ~/rpmbuild/SRPMS/
-	@cp $(PACKAGE)-$(VERSION).tar.gz ~/rpmbuild/SOURCES/
+	@cp $(PACKAGE)$(API_LEVEL)-$(VERSION).tar.gz ~/rpmbuild/SOURCES/
 	@rpmbuild -ba --clean rpm/spec
-	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-$(VERSION)*.rpm .
-	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-devel-$(VERSION)*.rpm .
-	@cp ~/rpmbuild/SRPMS/$(PACKAGE)-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)$(API_LEVEL)-devel-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/SRPMS/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm .
 
 rpm-sign: rpm-build
 	@rpm --addsign *.rpm

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -1,5 +1,5 @@
 Summary: Simplified API to MySQL databases
-Name: @PACKAGE@
+Name: @PACKAGE@@API_LEVEL@
 Version: @VERSION@
 Release: 1
 License: BSD
@@ -11,7 +11,7 @@ URL: https://github.com/sociomantic-tsunami/libdrizzle-redux
 %define packager_email %(git config user.email)
 Packager: %{packager_name} <%{packager_email}>
 
-Source: libdrizzle-redux-%{version}.tar.gz
+Source: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 
 %description


### PR DESCRIPTION
Addresses problem where apt-get install a newer version over an older. 
The PR adds the major version as suffix to the libname. 
Addresses #149 