### PR TITLE
Bugfix: skip NULL fields when reading from MySQL

### DIFF
--- a/libdrizzle/field.cc
+++ b/libdrizzle/field.cc
@@ -402,9 +402,21 @@ drizzle_return_t drizzle_state_binary_field_read(drizzle_st *con)
 {
   drizzle_return_t ret;
 
-  switch(con->result->column_buffer[con->result->field_current].type)
+  /* Skip NULL fields */
+  while (con->result->null_bitmap[(con->result->field_current_read + 2) / 8] &
+         (1 << ((con->result->field_current_read + 2) % 8)))
+  {
+    con->result->field_current_read++;
+  }
+
+  switch(con->result->column_buffer[con->result->field_current_read].type)
   {
     case DRIZZLE_COLUMN_TYPE_NULL:
+      /* This should not happen since NULL fields are masked by `null_bitmap`, but cover it anyway */
+      drizzle_set_error(con, __func__,
+        "Unexpected column type: DRIZZLE_COLUMN_TYPE_NULL");
+      con->result->field_size= 0;
+      return DRIZZLE_RETURN_UNEXPECTED_DATA;
       break;
     case DRIZZLE_COLUMN_TYPE_TINY:
       con->result->field_size= 1;
@@ -462,6 +474,7 @@ drizzle_return_t drizzle_state_binary_field_read(drizzle_st *con)
   con->result->field_total= con->result->field_size;
 
   con->result->field_current++;
+  con->result->field_current_read++;
   con->pop_state();
   return DRIZZLE_RETURN_OK;
 }

--- a/libdrizzle/result.h
+++ b/libdrizzle/result.h
@@ -65,6 +65,7 @@ struct drizzle_result_st
   uint64_t row_current;
 
   uint16_t field_current;         /* field index */
+  uint16_t field_current_read;    /* index of the field currently being read */
   uint64_t field_total;           /* total length of the field currently being read */
   uint64_t field_offset;          /* offset within field of most recently read field fragment (0 if first/only fragment) */
   uint32_t field_size;            /* size of most recently read field value or fragment of field value; max 2^24 */
@@ -102,6 +103,7 @@ struct drizzle_result_st
     row_count(0),
     row_current(0),
     field_current(0),
+    field_current_read(0),
     field_total(0),
     field_offset(0),
     field_size(0),

--- a/libdrizzle/row.cc
+++ b/libdrizzle/row.cc
@@ -303,6 +303,7 @@ drizzle_return_t drizzle_state_row_read(drizzle_st *con)
     con->result->row_count++;
     con->result->row_current++;
     con->result->field_current= 0;
+    con->result->field_current_read= 0;
   }
 
   con->pop_state();

--- a/libdrizzle/statement.cc
+++ b/libdrizzle/statement.cc
@@ -392,7 +392,6 @@ drizzle_return_t drizzle_stmt_fetch(drizzle_stmt_st *stmt)
   drizzle_return_t ret= DRIZZLE_RETURN_OK;
   uint16_t column_counter= 0, current_column= 0;
   drizzle_row_t row;
-  drizzle_column_st *column;
 
   if (stmt == NULL)
   {
@@ -422,11 +421,12 @@ drizzle_return_t drizzle_stmt_fetch(drizzle_stmt_st *stmt)
   {
     return DRIZZLE_RETURN_ROW_END;
   }
-  drizzle_column_seek(stmt->execute_result, 0);
 
   for (column_counter = 0; column_counter < stmt->execute_result->column_count; column_counter++)
   {
     drizzle_bind_st *param= &stmt->result_params[column_counter];
+    drizzle_column_st *column= drizzle_column_index(stmt->execute_result, column_counter);
+
     /* if this row is null in the result bitmap, skip first 2 bits */
     if (stmt->execute_result->null_bitmap[(column_counter+2)/8] & (1 << ((column_counter+2) % 8)))
     {
@@ -439,7 +439,6 @@ drizzle_return_t drizzle_stmt_fetch(drizzle_stmt_st *stmt)
       uint16_t short_data;
       uint32_t long_data;
       uint64_t longlong_data;
-      column= drizzle_column_next(stmt->execute_result);
       param->type= column->type;
       param->options.is_null= false;
       param->length= stmt->execute_result->field_sizes[current_column];

--- a/tests/unit/include.am
+++ b/tests/unit/include.am
@@ -141,3 +141,8 @@ nodist_EXTRA_tests_unit_statement_char_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/statement_char
 noinst_PROGRAMS+= tests/unit/statement_char
 
+tests_unit_statement_nulls_SOURCES= tests/unit/statement_nulls.c tests/unit/common.c
+tests_unit_statement_nulls_LDADD= libdrizzle/libdrizzle-redux.la
+nodist_EXTRA_tests_unit_statement_nulls_SOURCES = dummy.cxx
+check_PROGRAMS+= tests/unit/statement_nulls
+noinst_PROGRAMS+= tests/unit/statement_nulls

--- a/tests/unit/statement_nulls.c
+++ b/tests/unit/statement_nulls.c
@@ -1,0 +1,103 @@
+/*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
+ *
+ *  Drizzle Client & Protocol Library
+ *
+ * Copyright (C) 2012 Drizzle Developer Group
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *     * The names of its contributors may not be used to endorse or
+ * promote products derived from this software without specific prior
+ * written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#define _GNU_SOURCE
+
+#include "tests/unit/common.h"
+#include <yatl/lite.h>
+
+#include <libdrizzle-5.1/libdrizzle.h>
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string.h>
+
+int main(int argc, char *argv[])
+{
+  (void)argc;
+  (void)argv;
+  drizzle_result_st *result;
+  drizzle_return_t driz_ret;
+  drizzle_stmt_st *stmt;
+
+  set_up_connection();
+  set_up_schema("test_stmt_nulls");
+
+  CHECKED_QUERY("CREATE TABLE `t1` ("
+                "`a` int(10) NOT NULL AUTO_INCREMENT,"
+                "`b` varchar(255) NOT NULL,"
+                "`c` varchar(16) NOT NULL,"
+                "`d` varchar(32) DEFAULT NULL,"
+                "`e` varchar(255) DEFAULT NULL,"
+                "`f` varchar(255) DEFAULT NULL,"
+                "`g` int(1) NOT NULL DEFAULT '1',"
+                "`h` varchar(32) DEFAULT NULL,"
+                "`i` int(2) DEFAULT NULL,"
+                "`j` char(36) DEFAULT NULL,"
+                "PRIMARY KEY (`a`)"
+                ") ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8");
+
+  CHECKED_QUERY("INSERT INTO `t1` (`b`, `c`, `e`, `f`, `g`, `h`, `j`)"
+                "VALUES ('never', '1492672507', 'question', 'the',"
+                "0, 'answer', 'd7f15abb-a482-43be-99c2-c175408c1bd9')");
+
+  ASSERT_EQ(drizzle_result_affected_rows(result), 1);
+
+  const char *query= "SELECT * FROM t1";
+  stmt = drizzle_stmt_prepare(con, query, strlen(query), &driz_ret);
+  ASSERT_EQ_(driz_ret, DRIZZLE_RETURN_OK, "Error (%s): %s, preparing \"%s\"",
+             drizzle_strerror(driz_ret), drizzle_error(con), query);
+
+  driz_ret = drizzle_stmt_execute(stmt);
+  ASSERT_EQ_(driz_ret, DRIZZLE_RETURN_OK, "Error (%s): %s, executing \"%s\"",
+             drizzle_strerror(driz_ret), drizzle_error(con), query);
+  driz_ret = drizzle_stmt_buffer(stmt);
+  ASSERT_EQ_(driz_ret, DRIZZLE_RETURN_OK, "Error (%s): %s, buffering \"%s\"",
+             drizzle_strerror(driz_ret), drizzle_error(con), query);
+
+  ASSERT_EQ_(DRIZZLE_RETURN_OK, driz_ret, "drizzle_stmt_close() %s",
+             drizzle_error(con));
+
+  CHECKED_QUERY("DROP TABLE test_stmt_nulls.t1");
+
+  tear_down_schema("test_stmt_nulls");
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
In `drizzle_state_binary_field_read()` at `field.cc:401`

`NULL` fields have no bytes but bit-masked by `con->result->null_bitmap`, we should skip them.

For example, given table:
```sql
CREATE TABLE `test_table` (
  a VARCHAR(10) DEFAULT NULL,
  b VARCHAR(10) DEFAULT NULL,
  c INT(10) DEFAULT NULL,
  d VARCHAR(10) DEFAULT NULL
) ENGINE=InnoDB;
```

and row

| a     | b      | c   | d     |
| ----- | ------ | --- | ----- |
| test1 | `NULL` | 123 | test2 |

Since `NULL` fields are not presented in the response body, if we try to read field `b` from the response, it's not a valid operation and may cause serious problems.

This patch fixes this problem by skipping `NULL` fields when reading from MySQL's response.