### PR TITLE
Remove temp file generated by sphinx m4 macro

### DIFF
--- a/m4/ax_prog_sphinx_build.m4
+++ b/m4/ax_prog_sphinx_build.m4
@@ -38,6 +38,9 @@ AC_DEFUN([AX_PROG_SPHINX_BUILD],
                             AS_IF([test $? -eq 0], ,[SPHINXBUILD=])
                             rm -rf conftest.d ])
                       ])
+                      AS_IF([test -e "version_file"],
+                            [rm version_file])
+
                ])
 
          AS_IF([test -n "${SPHINXBUILD}"],


### PR DESCRIPTION
Fixes error when running `make distcheck``