### PR TITLE
Bugfix: compile error for unsupported socket option TCP_KEEPIDLE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,9 @@ AC_CHECK_HEADERS([windows.h])
 AC_CHECK_HEADERS([winsock2.h])
 AC_CHECK_HEADERS([ws2tcpip.h])
 
+# Check for setsockopt support
+AX_CHECK_SETSOCKOPT
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_TYPES([in_port_t])
 AC_TYPE_SSIZE_T

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -1634,7 +1634,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   ret = 1;
 #ifdef _WIN32
   ret= setsockopt(con->fd, SOL_SOCKET, SO_KEEPALIVE, (const char*)&ret, optlen_int);
-#else
+#elif defined HAVE_SO_KEEPALIVE
   ret= setsockopt(con->fd, SOL_SOCKET, SO_KEEPALIVE,&ret, optlen_int);
 #endif /* _WIN32 */
 
@@ -1648,7 +1648,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
 #ifdef _WIN32
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPIDLE,
                   (const char*)&con->options.keepidle, optlen_int);
-#else
+#elif defined HAVE_TCP_KEEPIDLE
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPIDLE,
                   &con->options.keepidle, optlen_int);
 #endif /* _WIN32 */
@@ -1662,7 +1662,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
 #ifdef _WIN32
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPCNT,
                   (const char*)&con->options.keepcnt, optlen_int);
-#else
+#elif defined HAVE_TCP_KEEPCNT
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPCNT, &con->options.keepcnt,
                   optlen_int);
 #endif /* _WIN32 */
@@ -1676,7 +1676,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
 #ifdef _WIN32
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPINTVL,
                   (const char*)&con->options.keepintvl, optlen_int);
-#else
+#elif defined HAVE_TCP_KEEPINTVL
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPINTVL,
                   &con->options.keepintvl, optlen_int);
 #endif /* _WIN32 */

--- a/libdrizzle/conn.cc
+++ b/libdrizzle/conn.cc
@@ -1541,6 +1541,16 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   struct timeval waittime;
   const socklen_t optlen_int = sizeof(int);
 
+#if defined _WIN32
+  typedef const char* sockopt_value_t;
+  typedef const char* sockopt_linger_t;
+  typedef const char* sockopt_timeval_t;
+#else
+  typedef int* sockopt_value_t ;
+  typedef struct linger* sockopt_linger_t;
+  typedef struct timeval* sockopt_timeval_t;
+#endif
+
   assert(con);
   if (con == NULL)
   {
@@ -1570,11 +1580,8 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
 
   int ret= 1;
 
-#ifdef _WIN32
-  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_NODELAY, (const char*)&ret, optlen_int);
-#else
-  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_NODELAY, &ret, optlen_int);
-#endif /* _WIN32 */
+  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_NODELAY, (sockopt_value_t)&ret,
+    optlen_int);
 
   if (ret == -1 && errno != EOPNOTSUPP)
   {
@@ -1585,13 +1592,8 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   linger.l_onoff= 1;
   linger.l_linger= con->options.wait_timeout;
 
-#ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_LINGER, (const char*)&linger,
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_LINGER, (sockopt_linger_t)&linger,
                   (socklen_t)sizeof(struct linger));
-#else
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_LINGER, &linger,
-                  (socklen_t)sizeof(struct linger));
-#endif /* _WIN32 */
 
   if (ret == -1)
   {
@@ -1602,13 +1604,8 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   waittime.tv_sec= con->options.wait_timeout;
   waittime.tv_usec= 0;
 
-#ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDTIMEO, (const char*)&waittime,
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDTIMEO, (sockopt_timeval_t)&waittime,
                   (socklen_t)sizeof(struct timeval));
-#else
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDTIMEO, &waittime,
-                  (socklen_t)sizeof(struct timeval));
-#endif /* _WIN32 */
 
   if (ret == -1 && errno != ENOPROTOOPT)
   {
@@ -1616,13 +1613,8 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
     return DRIZZLE_RETURN_ERRNO;
   }
 
-#ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&waittime,
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVTIMEO, (sockopt_timeval_t)&waittime,
                   (socklen_t)sizeof(struct timeval));
-#else
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVTIMEO, &waittime,
-                  (socklen_t)sizeof(struct timeval));
-#endif /* _WIN32 */
 
   if (ret == -1 && errno != ENOPROTOOPT)
   {
@@ -1632,11 +1624,10 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   }
 
   ret = 1;
-#ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_KEEPALIVE, (const char*)&ret, optlen_int);
-#elif defined HAVE_SO_KEEPALIVE
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_KEEPALIVE,&ret, optlen_int);
-#endif /* _WIN32 */
+
+#ifdef HAVE_SO_KEEPALIVE
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_KEEPALIVE, (sockopt_value_t)&ret,
+    optlen_int);
 
   if (ret == -1 && errno != ENOPROTOOPT)
   {
@@ -1644,55 +1635,42 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
                       "setsockopt:SO_KEEPALIVE:%s", strerror(errno));
     return DRIZZLE_RETURN_ERRNO;
   }
+#endif /* HAVE_SO_KEEPALIVE */
 
-#ifdef _WIN32
+#ifdef HAVE_TCP_KEEPIDLE
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPIDLE,
-                  (const char*)&con->options.keepidle, optlen_int);
-#elif defined HAVE_TCP_KEEPIDLE
-  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPIDLE,
-                  &con->options.keepidle, optlen_int);
-#endif /* _WIN32 */
-
+                  (sockopt_value_t)&con->options.keepidle, optlen_int);
   if (ret == -1 && errno != EOPNOTSUPP)
   {
     drizzle_set_error(con, __func__, "setsockopt:TCP_KEEPIDLE:%s", strerror(errno));
     return DRIZZLE_RETURN_ERRNO;
   }
+#endif /* HAVE_TCP_KEEPIDLE */
 
-#ifdef _WIN32
+#ifdef HAVE_TCP_KEEPCNT
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPCNT,
-                  (const char*)&con->options.keepcnt, optlen_int);
-#elif defined HAVE_TCP_KEEPCNT
-  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPCNT, &con->options.keepcnt,
-                  optlen_int);
-#endif /* _WIN32 */
-
+                  (sockopt_value_t)&con->options.keepcnt, optlen_int);
   if (ret == -1 && errno != EOPNOTSUPP)
   {
     drizzle_set_error(con, __func__, "setsockopt:TCP_KEEPCNT:%s", strerror(errno));
     return DRIZZLE_RETURN_ERRNO;
   }
+#endif /* HAVE_TCP_KEEPCNT */
 
-#ifdef _WIN32
+#ifdef HAVE_TCP_KEEPINTVL
   ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPINTVL,
-                  (const char*)&con->options.keepintvl, optlen_int);
-#elif defined HAVE_TCP_KEEPINTVL
-  ret= setsockopt(con->fd, IPPROTO_TCP, TCP_KEEPINTVL,
-                  &con->options.keepintvl, optlen_int);
-#endif /* _WIN32 */
+                  (sockopt_value_t)&con->options.keepintvl, optlen_int);
+
 
   if (ret == -1 && errno != EOPNOTSUPP)
   {
     drizzle_set_error(con, __func__, "setsockopt:TCP_KEEPINTVL:%s", strerror(errno));
     return DRIZZLE_RETURN_ERRNO;
   }
+#endif /* HAVE_TCP_KEEPINTVL */
 
   ret= DRIZZLE_DEFAULT_SOCKET_SEND_SIZE;
-#ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDBUF, (const char*)&ret, optlen_int);
-#else
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDBUF, &ret, optlen_int);
-#endif /* _WIN32 */
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_SNDBUF, (sockopt_value_t)&ret, optlen_int);
   if (ret == -1)
   {
     drizzle_set_error(con, __func__, "setsockopt:SO_SNDBUF:%s", strerror(errno));
@@ -1700,11 +1678,7 @@ static drizzle_return_t _setsockopt(drizzle_st *con)
   }
 
   ret= DRIZZLE_DEFAULT_SOCKET_RECV_SIZE;
-#ifdef _WIN32
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVBUF, (const char*)&ret, optlen_int);
-#else
-  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVBUF, &ret, optlen_int);
-#endif /* _WIN32 */
+  ret= setsockopt(con->fd, SOL_SOCKET, SO_RCVBUF, (sockopt_value_t)&ret, optlen_int);
   if (ret == -1)
   {
     drizzle_set_error(con, __func__, "setsockopt:SO_RCVBUF:%s", strerror(errno));

--- a/m4/ax_check_setsockopt.m4
+++ b/m4/ax_check_setsockopt.m4
@@ -1,0 +1,217 @@
+dnl @synopsis Tests for socket options capability.
+dnl
+dnl Defines support for the following options:
+dnl     SO_KEEPALIVE
+dnl     TCP_KEEPALIVE
+dnl     TCP_KEEPCNT
+dnl     TCP_KEEPIDLE
+dnl     TCP_KEEPINTVL
+dnl
+dnl The macro is a modified version of the acinclude.m4 from the ZeroMQ library
+dnl http://github.com/zeromq/libzmq
+dnl
+dnl @license Mozilla Public License v2 (MPLv2)
+
+
+dnl ############################################################################
+dnl # CHECK_SO_KEEPALIVE([action-if-found], [action-if-not-found])             #
+dnl # Check if SO_KEEPALIVE is supported                                       #
+dnl ############################################################################
+AC_DEFUN([CHECK_SO_KEEPALIVE], [{
+    AC_MSG_CHECKING(whether SO_KEEPALIVE is supported)
+    AC_RUN_IFELSE([/* SO_KEEPALIVE test */
+        AC_LANG_PROGRAM([
+#if defined(HAVE_WINSOCK2_H) && HAVE_WINSOCK2_H
+# include <winsock2.h>
+# include <windows.h>
+# else
+# include <sys/types.h>
+# include <sys/socket.h>
+#endif
+],[
+int main (int argc, char *argv [])
+{
+    int s, rc, opt = 1;
+    return (
+        ((s = socket (PF_INET, SOCK_STREAM, 0)) == -1) ||
+        ((rc = setsockopt (s, SOL_SOCKET, SO_KEEPALIVE, (char*) &opt, sizeof (int))) == -1) ||
+        ((rc = setsockopt (s, SOL_SOCKET, SO_KEEPALIVE, (int*) &opt, sizeof (int))) == -1)
+    );
+}
+    ])],
+    [AC_MSG_RESULT(yes) ; cv_so_keepalive="yes" ; $1],
+    [AC_MSG_RESULT(no)  ; cv_so_keepalive="no"  ; $2],
+    [AC_MSG_RESULT(not during cross-compile) ; cv_so_keepalive="no"]
+    )
+}])
+
+dnl ############################################################################
+dnl # CHECK_TCP_KEEPCNT([action-if-found], [action-if-not-found])              #
+dnl # Check if TCP_KEEPCNT is supported                                        #
+dnl ############################################################################
+AC_DEFUN([CHECK_TCP_KEEPCNT], [{
+    AC_MSG_CHECKING(whether TCP_KEEPCNT is supported)
+    AC_RUN_IFELSE([/* TCP_KEEPCNT test */
+        AC_LANG_PROGRAM([
+#if defined(HAVE_WINSOCK2_H) && HAVE_WINSOCK2_H
+# include <winsock2.h>
+# include <windows.h>
+#else
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
+# include <netinet/tcp.h>
+#endif
+],[
+int main (int argc, char *argv [])
+{
+    int s, rc, opt = 1;
+    return (
+        ((s = socket (PF_INET, SOCK_STREAM, 0)) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPCNT, (char*) &opt, sizeof (int))) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPCNT, (int*) &opt, sizeof (int))) == -1)
+    );
+}
+    ])],
+    [AC_MSG_RESULT(yes) ; cv_tcp_keepcnt="yes" ; $1],
+    [AC_MSG_RESULT(no)  ; cv_tcp_keepcnt="no"  ; $2],
+    [AC_MSG_RESULT(not during cross-compile) ; cv_tcp_keepcnt="no"]
+    )
+}])
+
+dnl ############################################################################
+dnl # CHECK_TCP_KEEPIDLE([action-if-found], [action-if-not-found])             #
+dnl # Check if TCP_KEEPIDLE is supported                                       #
+dnl ############################################################################
+AC_DEFUN([CHECK_TCP_KEEPIDLE], [{
+    AC_MSG_CHECKING(whether TCP_KEEPIDLE is supported)
+    AC_RUN_IFELSE([/* TCP_KEEPIDLE test */
+        AC_LANG_PROGRAM([
+#if defined(HAVE_WINSOCK2_H) && HAVE_WINSOCK2_H
+# include <winsock2.h>
+# include <windows.h>
+#else
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
+# include <netinet/tcp.h>
+#endif
+],[
+int main (int argc, char *argv [])
+{
+    int s, rc, opt = 1;
+    return (
+        ((s = socket (PF_INET, SOCK_STREAM, 0)) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPIDLE, (char*) &opt, sizeof (int))) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPIDLE, (int*) &opt, sizeof (int))) == -1)
+    );
+}
+    ])],
+    [AC_MSG_RESULT(yes) ; cv_tcp_keepidle="yes" ; $1],
+    [AC_MSG_RESULT(no)  ; cv_tcp_keepidle="no"  ; $2],
+    [AC_MSG_RESULT(not during cross-compile) ; cv_tcp_keepidle="no"]
+    )
+}])
+
+dnl ############################################################################
+dnl # CHECK_TCP_KEEPINTVL([action-if-found], [action-if-not-found])            #
+dnl # Check if TCP_KEEPINTVL is supported                                      #
+dnl ############################################################################
+AC_DEFUN([CHECK_TCP_KEEPINTVL], [{
+    AC_MSG_CHECKING(whether TCP_KEEPINTVL is supported)
+    AC_RUN_IFELSE([/* TCP_KEEPINTVL test */
+        AC_LANG_PROGRAM([
+#if defined(HAVE_WINSOCK2_H) && HAVE_WINSOCK2_H
+# include <winsock2.h>
+# include <windows.h>
+#else
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
+# include <netinet/tcp.h>
+#endif
+],[
+int main (int argc, char *argv [])
+{
+    int s, rc, opt = 1;
+    return (
+        ((s = socket (PF_INET, SOCK_STREAM, 0)) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPINTVL, (const char*) &opt, sizeof (int))) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPINTVL, (int*) &opt, sizeof (int))) == -1)
+    );
+}
+    ])],
+    [AC_MSG_RESULT(yes) ; cv_tcp_keepintvl="yes" ; $1],
+    [AC_MSG_RESULT(no)  ; cv_tcp_keepintvl="no"  ; $2],
+    [AC_MSG_RESULT(not during cross-compile) ; cv_tcp_keepintvl="no"]
+    )
+}])
+
+dnl ############################################################################
+dnl # CHECK_TCP_KEEPALIVE([action-if-found], [action-if-not-found])            #
+dnl # Check if TCP_KEEPALIVE is supported                                      #
+dnl ############################################################################
+AC_DEFUN([CHECK_TCP_KEEPALIVE], [{
+    AC_MSG_CHECKING(whether TCP_KEEPALIVE is supported)
+    AC_RUN_IFELSE([ /* TCP_KEEPALIVE test */
+        AC_LANG_PROGRAM([
+#if defined(HAVE_WINSOCK2_H) && HAVE_WINSOCK2_H
+# include <winsock2.h>
+# include <windows.h>
+#else
+# include <sys/types.h>
+# include <sys/socket.h>
+# include <netinet/in.h>
+# include <netinet/tcp.h>
+#endif
+],
+[
+int main (int argc, char *argv [])
+{
+    int s, rc, opt = 1;
+    return (
+        ((s = socket (PF_INET, SOCK_STREAM, 0)) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPALIVE, (const char*) &opt, sizeof (int))) == -1) ||
+        ((rc = setsockopt (s, IPPROTO_TCP, TCP_KEEPALIVE, (int*) &opt, sizeof (int))) == -1)
+    );
+}
+    ])],
+    [AC_MSG_RESULT(yes) ; cv_tcp_keepalive="yes" ; $1],
+    [AC_MSG_RESULT(no)  ; cv_tcp_keepalive="no"  ; $2],
+    [AC_MSG_RESULT(not during cross-compile) ; cv_tcp_keepalive="no"]
+    )
+}])
+
+AC_DEFUN([AX_CHECK_SETSOCKOPT],
+  [AC_MSG_CHECKING(which socket options are supported)
+    # TCP Socket option checks.
+    CHECK_SO_KEEPALIVE([
+        AC_DEFINE([HAVE_SO_KEEPALIVE],
+            [1],
+            [Whether SO_KEEPALIVE is supported.])
+        ])
+
+    CHECK_TCP_KEEPCNT([
+        AC_DEFINE([HAVE_TCP_KEEPCNT],
+            [1],
+            [Whether TCP_KEEPCNT is supported.])
+        ])
+
+    CHECK_TCP_KEEPIDLE([
+        AC_DEFINE([HAVE_TCP_KEEPIDLE],
+            [1],
+            [Whether TCP_KEEPIDLE is supported.])
+        ])
+
+    CHECK_TCP_KEEPINTVL([
+        AC_DEFINE([HAVE_TCP_KEEPINTVL],
+            [1],
+            [Whether TCP_KEEPINTVL is supported.])
+        ])
+
+    CHECK_TCP_KEEPALIVE([
+        AC_DEFINE([HAVE_TCP_KEEPALIVE],
+            [1],
+            [Whether TCP_KEEPALIVE is supported.])
+        ])
+  ])


### PR DESCRIPTION
Fix the issue reported in #155 
Also sanitizes the use preprocessor checks for _WIN32 in the internal `_setsockopt` function. 
 