### PR TITLE
Correctly set the SONAME for libdrizzle-redux6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ deb/install
 .deps
 docs/conf.py
 src/.*
-libdrizzle-redux-config
+libdrizzle-redux?-config
 version.h
 libtool
 m4/libtool.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,6 @@ CLEANFILES =
 DISTCLEANFILES =
 bin_PROGRAMS =
 dist_bin_SCRIPTS =
-distdir = @PACKAGE@@API_LEVEL@-@VERSION@
 noinst_HEADERS =
 lib_LTLIBRARIES =
 man_MANS =
@@ -70,8 +69,8 @@ maintainer-clean-local:
 	-rm m4/ltversion.m4
 	-rm m4/lt~obsolete.m4
 	find . -type f -name '*~' -exec rm -f '{}' \;
-	-rm -f @PACKAGE@@API_LEVEL@-*.tar.gz
-	-rm -f rpm/@PACKAGE@@API_LEVEL@-*.rpm
-	-rm -f @PACKAGE@@API_LEVEL@-*.deb
+	-rm -f @PACKAGE@-*.tar.gz
+	-rm -f rpm/@PACKAGE@-*.rpm
+	-rm -f @PACKAGE@-*.deb
 
 dist_bin_SCRIPTS+= @GENERIC_CONFIG@

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 # Use and distribution licensed under the BSD license.  See
 # the COPYING file in this directory for full text.
 
-AC_INIT([libdrizzle-redux],[6.0.2],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
+AC_INIT([libdrizzle-redux6],[6.0.2],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux6],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -15,12 +15,6 @@ AC_CANONICAL_TARGET
 # Automake version before 1.13 (when the serial-tests option was dnl still the default) still defined the badly obsolete macro.  'AM_PROG_INSTALL'.
 AM_INIT_AUTOMAKE(1.11 no-define color-tests -Wno-portability subdir-objects foreign tar-ustar m4_ifndef([AM_WITH_REGEX], [serial-tests]))
 AC_PREREQ([2.68])
-
-# Define the api level of the package.
-AC_SUBST([API_LEVEL],[6])
-
-# Add the api level to the name of the generated tar file
-AC_SUBST([PACKAGE_TARNAME],[$PACKAGE_NAME$API_LEVEL])
 
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
@@ -73,6 +67,10 @@ LIBDRIZZLE_LIBRARY_VERSION=13:2:0
 #                  |           set to zero if current is incremented
 #                  +- increment if interfaces have been added, removed or changed
 AC_SUBST([LIBDRIZZLE_LIBRARY_VERSION])
+
+# This is used to allow multiple major (SemVer-wise) to be installed concurrently
+LIBDRIZZLE_MAJOR=6
+AC_SUBST([LIBDRIZZLE_MAJOR])
 
 LT_PREREQ([2.2])
 LT_INIT

--- a/deb/build
+++ b/deb/build
@@ -112,7 +112,7 @@ fpm -s dir -t deb -n "$dist_pkgname" -v "$pkgversion" \
 genchangelog "$dist_pkgname-dbg" "$pkgversion" "$pkgmaint" > "$changelog"
 build_id=`readelf -n $so_libname.$libversion | \
     sed -n 's/^.*Build ID: \([a-f0-9]\{40\}\).*$/\1/p'`
-debug_file=`printf $build_id | cut -b1-2`/`printf $build_id | cut -b3-`.debug
+debug_file=`echo $build_id | cut -b1-2`/`echo $build_id | cut -b3-`.debug
 objcopy --only-keep-debug $so_libname.$libversion.full $so_libname.$libversion.debug
 fpm -s dir -t deb -n "$dist_pkgname-dbg" -v "$pkgversion" \
     --architecture all \

--- a/deb/build
+++ b/deb/build
@@ -3,15 +3,36 @@
 # script using fpm <https://github.com/jordansissel/fpm> to build libdrizzle-redux
 # runtime, debugging and development deb packages
 #
-# Usage: ./build [api_level]
+# Usage: ./build [package-name]
 #
-#     api_level        the api level for the package
-#
-# The `api_level` will be appended to the `package_name` for the generated
-# packages, i.e. running `./build 6` would generate a packages named
-# `libdrizzle-redux6`, `libdrizzle-redux6-dbg`, `libdrizzle-redux6-dev`.
+#     package-name        the name of the package to build
+
+# function to display usage
+usage()
+{
+    cat << EOF
+The script is using fpm <https://github.com/jordansissel/fpm> to build
+libdrizzle-redux runtime, debugging and development deb packages
+
+    Usage: ./build [package-name]
+
+    package-name    the name of the package to build
+    -h, --help      display this help and exit
+EOF
+}
 
 set -e
+
+# check cmd arguments
+if [ -z "$1" ]; then
+    echo "Expected package name as first argument"
+    usage
+    exit 1
+elif [ $1 = "--help" -o  $1 = "-h" ]
+then
+    usage
+    exit 0
+fi
 
 # cd to the directory containing the deb `build` script
 cd `dirname $0`
@@ -38,23 +59,11 @@ pkgversion=$(git describe --dirty | cut -c2- |
 # get package maintainer info
 pkgmaint=$(echo "`git config user.name` <`git config user.email`>")
 
-# package name
-pkgname=libdrizzle-redux
+# the package name used in the distribution
+pkgname=$1
 
 # library .so name
 so_libname=$pkgname.so
-
-# get the api level for the package from the cmd args
-api_level=""
-if [ $# -eq 1 -a ! -z "$1" ]; then
-    api_level=$1
-fi
-
-# the package name used in the distribution
-dist_pkgname=$pkgname$api_level
-
-# the so library name used in the distribution
-dist_so_libname=$dist_pkgname.so
 
 # relative path to the directory with library files to install
 libdir="./install/usr/lib"
@@ -73,13 +82,6 @@ lib_major=$(echo $libversion | cut -f1 -d .)
 changelog=`mktemp`
 trap "rm -f '$changelog'; exit 1" INT TERM QUIT
 
-# (re)create symbolic links with the distributed package name, dist_pkgname
-cd $libdir
-touch $dist_so_libname.$libversion
-ln -sf $dist_so_libname.$libversion $dist_so_libname.$lib_major
-ln -sf $dist_so_libname.$lib_major $dist_so_libname
-cd -
-
 # prepend the relative file path to so_libname
 so_libname="$libdir/$so_libname"
 
@@ -90,8 +92,8 @@ cp $so_libname.$libversion $so_libname.$libversion.full
 strip $so_libname.$libversion
 
 # libdrizzle-redux runtime package
-genchangelog "$dist_pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
-fpm -s dir -t deb -n "$dist_pkgname" -v "$pkgversion" \
+genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
+fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
     --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
@@ -105,16 +107,16 @@ fpm -s dir -t deb -n "$dist_pkgname" -v "$pkgversion" \
     --depends libgcc1 \
     --deb-changelog "$changelog" \
     --deb-no-default-config-files \
-    $so_libname.$libversion=/usr/lib/$dist_pkgname.so.$libversion \
-    $libdir/$dist_so_libname.$lib_major=/usr/lib/
+    $so_libname.$libversion=/usr/lib/ \
+    $so_libname.$lib_major=/usr/lib/
 
 # libdrizzle-redux debug package
-genchangelog "$dist_pkgname-dbg" "$pkgversion" "$pkgmaint" > "$changelog"
+genchangelog "$pkgname-dbg" "$pkgversion" "$pkgmaint" > "$changelog"
 build_id=`readelf -n $so_libname.$libversion | \
     sed -n 's/^.*Build ID: \([a-f0-9]\{40\}\).*$/\1/p'`
 debug_file=`echo $build_id | cut -b1-2`/`echo $build_id | cut -b3-`.debug
 objcopy --only-keep-debug $so_libname.$libversion.full $so_libname.$libversion.debug
-fpm -s dir -t deb -n "$dist_pkgname-dbg" -v "$pkgversion" \
+fpm -s dir -t deb -n "$pkgname-dbg" -v "$pkgversion" \
     --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
@@ -122,14 +124,17 @@ fpm -s dir -t deb -n "$dist_pkgname-dbg" -v "$pkgversion" \
     --vendor 'Sociomantic Labs GmbH' \
     --license 'Simplified BSD License' \
     --category debug \
-    --depends $dist_pkgname \
+    --depends $pkgname \
     --deb-changelog "$changelog" \
     --deb-no-default-config-files \
     $so_libname.$libversion.debug=/usr/lib/debug/.build-id/$debug_file
 
 # libdrizzle-redux development package
-genchangelog "$dist_pkgname-dev" "$pkgversion" "$pkgmaint" > "$changelog"
-fpm -s dir -t deb -n "$dist_pkgname-dev" -v "$pkgversion" \
+#
+# the development headers are installed into a directory of the form:
+#       /usr/include/libdrizzle-redux[MAJOR]/libdrizzle-redux
+genchangelog "$pkgname-dev" "$pkgversion" "$pkgmaint" > "$changelog"
+fpm -s dir -t deb -n "$pkgname-dev" -v "$pkgversion" \
     --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
@@ -137,9 +142,9 @@ fpm -s dir -t deb -n "$dist_pkgname-dev" -v "$pkgversion" \
     --vendor 'Sociomantic Labs GmbH' \
     --license 'Simplified BSD License' \
     --category libdevel \
-    --depends $dist_pkgname \
+    --depends $pkgname \
     --deb-changelog "$changelog" \
     --deb-no-default-config-files \
-    install/usr/include/include/=/usr/include/$pkgname/$dist_pkgname/ \
-    $libdir/$dist_so_libname=/usr/lib/ \
-    $libdir/$pkgname.a=/usr/lib/$dist_pkgname.a
+    install/usr/include/include/=/usr/include/$pkgname/ \
+    $so_libname=/usr/lib/ \
+    $libdir/$pkgname.a=/usr/lib/

--- a/deb/include.am
+++ b/deb/include.am
@@ -9,7 +9,7 @@
 deb: clean-deb
 	./configure --prefix=/usr
 	$(MAKE) DESTDIR=${abs_builddir}/deb/install install
-	deb/build $(API_LEVEL)
+	deb/build $(PACKAGE)
 
 release-deb:
 	@read -p "Enter version (previous: $$(git describe --abbrev=0)): " version; \

--- a/rpm/include.am
+++ b/rpm/include.am
@@ -2,8 +2,8 @@
 
 rpm-build: rpm/spec dist
 	@rm -f *.rpm
-	@rm -f ~/rpmbuild/RPMS/x86_64/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm
-	@rm -f ~/rpmbuild/SRPMS/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm
+	@rm -f ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-$(VERSION)*.rpm
+	@rm -f ~/rpmbuild/SRPMS/$(PACKAGE)-$(VERSION)*.rpm
 	@mkdir -p ~/rpmbuild/BUILD/
 	@mkdir -p ~/rpmbuild/RPMS/i386/
 	@mkdir -p ~/rpmbuild/RPMS/i686/
@@ -12,11 +12,11 @@ rpm-build: rpm/spec dist
 	@mkdir -p ~/rpmbuild/SOURCES/
 	@mkdir -p ~/rpmbuild/SPECS/
 	@mkdir -p ~/rpmbuild/SRPMS/
-	@cp $(PACKAGE)$(API_LEVEL)-$(VERSION).tar.gz ~/rpmbuild/SOURCES/
+	@cp $(PACKAGE)-$(VERSION).tar.gz ~/rpmbuild/SOURCES/
 	@rpmbuild -ba --clean rpm/spec
-	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm .
-	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)$(API_LEVEL)-devel-$(VERSION)*.rpm .
-	@cp ~/rpmbuild/SRPMS/$(PACKAGE)$(API_LEVEL)-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/RPMS/x86_64/$(PACKAGE)-devel-$(VERSION)*.rpm .
+	@cp ~/rpmbuild/SRPMS/$(PACKAGE)-$(VERSION)*.rpm .
 
 rpm-sign: rpm-build
 	@rpm --addsign *.rpm

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -1,5 +1,5 @@
 Summary: Simplified API to MySQL databases
-Name: @PACKAGE@@API_LEVEL@
+Name: @PACKAGE@
 Version: @VERSION@
 Release: 1
 License: BSD
@@ -45,9 +45,9 @@ you will need to install %{name}-devel.
 # rename the directory to `include/libdrizzle-redux`
 if test -d %{rpm_include_path}
 then
-    tmp_include_path=`echo %{rpm_include_path} | sed 's/include\/include/include/'`
-    mv %{rpm_include_path} ${tmp_include_path}
-    rm -rf %{rpm_include_path}
+    tmp_include_path=$RPM_BUILD_ROOT/usr/include/%{header_install_path}
+    mkdir -p $tmp_include_path
+    mv %{rpm_include_path} ${tmp_include_path}/
 fi
 mkdir -p $RPM_BUILD_ROOT/
 
@@ -60,37 +60,37 @@ mkdir -p $RPM_BUILD_ROOT/
 %files
 %defattr(-,root,root,-)
 %doc AUTHORS COPYING
-%{_libdir}/libdrizzle-redux.a
-%{_libdir}/libdrizzle-redux.la
-%{_libdir}/libdrizzle-redux.so
-%{_libdir}/libdrizzle-redux.so.*
-%{_bindir}/libdrizzle-redux-config
+%{_libdir}/%{name}.a
+%{_libdir}/%{name}.la
+%{_libdir}/%{name}.so
+%{_libdir}/%{name}.so.*
+%{_bindir}/%{name}-config
 
 %files devel
 %defattr(-,root,root,-)
 %doc AUTHORS COPYING
-%{_includedir}/libdrizzle-redux/binlog.h
-%{_includedir}/libdrizzle-redux/column.h
-%{_includedir}/libdrizzle-redux/column_client.h
-%{_includedir}/libdrizzle-redux/conn.h
-%{_includedir}/libdrizzle-redux/conn_client.h
-%{_includedir}/libdrizzle-redux/constants.h
-%{_includedir}/libdrizzle-redux/drizzle.h
-%{_includedir}/libdrizzle-redux/drizzle_client.h
-%{_includedir}/libdrizzle-redux/error.h
-%{_includedir}/libdrizzle-redux/field_client.h
-%{_includedir}/libdrizzle-redux/libdrizzle.h
-%{_includedir}/libdrizzle-redux/query.h
-%{_includedir}/libdrizzle-redux/result.h
-%{_includedir}/libdrizzle-redux/result_client.h
-%{_includedir}/libdrizzle-redux/return.h
-%{_includedir}/libdrizzle-redux/row_client.h
-%{_includedir}/libdrizzle-redux/ssl.h
-%{_includedir}/libdrizzle-redux/statement.h
-%{_includedir}/libdrizzle-redux/structs.h
-%{_includedir}/libdrizzle-redux/verbose.h
-%{_includedir}/libdrizzle-redux/version.h
-%{_includedir}/libdrizzle-redux/visibility.h
+%{_includedir}/%{name}/libdrizzle-redux/binlog.h
+%{_includedir}/%{name}/libdrizzle-redux/column.h
+%{_includedir}/%{name}/libdrizzle-redux/column_client.h
+%{_includedir}/%{name}/libdrizzle-redux/conn.h
+%{_includedir}/%{name}/libdrizzle-redux/conn_client.h
+%{_includedir}/%{name}/libdrizzle-redux/constants.h
+%{_includedir}/%{name}/libdrizzle-redux/drizzle.h
+%{_includedir}/%{name}/libdrizzle-redux/drizzle_client.h
+%{_includedir}/%{name}/libdrizzle-redux/error.h
+%{_includedir}/%{name}/libdrizzle-redux/field_client.h
+%{_includedir}/%{name}/libdrizzle-redux/libdrizzle.h
+%{_includedir}/%{name}/libdrizzle-redux/query.h
+%{_includedir}/%{name}/libdrizzle-redux/result.h
+%{_includedir}/%{name}/libdrizzle-redux/result_client.h
+%{_includedir}/%{name}/libdrizzle-redux/return.h
+%{_includedir}/%{name}/libdrizzle-redux/row_client.h
+%{_includedir}/%{name}/libdrizzle-redux/ssl.h
+%{_includedir}/%{name}/libdrizzle-redux/statement.h
+%{_includedir}/%{name}/libdrizzle-redux/structs.h
+%{_includedir}/%{name}/libdrizzle-redux/verbose.h
+%{_includedir}/%{name}/libdrizzle-redux/version.h
+%{_includedir}/%{name}/libdrizzle-redux/visibility.h
 
 %changelog
 * Fri May 12 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> v6.0.2

--- a/src/include.am
+++ b/src/include.am
@@ -19,50 +19,50 @@ noinst_HEADERS+= src/statement_local.h
 noinst_HEADERS+= src/structs.h
 noinst_HEADERS+= src/windows.hpp
 
-lib_LTLIBRARIES+= src/libdrizzle-redux.la
-src_libdrizzle_redux_la_SOURCES=
-src_libdrizzle_redux_la_LIBADD=
-src_libdrizzle_redux_la_LDFLAGS=
-src_libdrizzle_redux_la_CFLAGS= -DBUILDING_LIBDRIZZLE
-src_libdrizzle_redux_la_CXXFLAGS= -DBUILDING_LIBDRIZZLE
+lib_LTLIBRARIES+= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_SOURCES=
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LIBADD=
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LDFLAGS=
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CFLAGS= -DBUILDING_LIBDRIZZLE
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CXXFLAGS= -DBUILDING_LIBDRIZZLE
 
-src_libdrizzle_redux_la_CFLAGS+= @OPENSSL_INCLUDES@
-src_libdrizzle_redux_la_CXXFLAGS+= @OPENSSL_INCLUDES@
-src_libdrizzle_redux_la_LDFLAGS+= @OPENSSL_LDFLAGS@
-src_libdrizzle_redux_la_LIBADD+= @OPENSSL_LIBS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CFLAGS+= @OPENSSL_INCLUDES@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CXXFLAGS+= @OPENSSL_INCLUDES@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LDFLAGS+= @OPENSSL_LDFLAGS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LIBADD+= @OPENSSL_LIBS@
 
-src_libdrizzle_redux_la_CFLAGS+= @PTHREAD_CFLAGS@
-src_libdrizzle_redux_la_CXXFLAGS+= @PTHREAD_CFLAGS@
-src_libdrizzle_redux_la_LIBADD+= @PTHREAD_LIBS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CFLAGS+= @PTHREAD_CFLAGS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CXXFLAGS+= @PTHREAD_CFLAGS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LIBADD+= @PTHREAD_LIBS@
 
-src_libdrizzle_redux_la_CFLAGS+= @ZLIB_CFLAGS@
-src_libdrizzle_redux_la_CXXFLAGS+= @ZLIB_CFLAGS@
-src_libdrizzle_redux_la_LDFLAGS+= @ZLIB_LDFLAGS@
-src_libdrizzle_redux_la_LIBADD+= @ZLIB_LIBS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CFLAGS+= @ZLIB_CFLAGS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_CXXFLAGS+= @ZLIB_CFLAGS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LDFLAGS+= @ZLIB_LDFLAGS@
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LIBADD+= @ZLIB_LIBS@
 
 if BUILD_WIN32
-src_libdrizzle_redux_la_LIBADD+= -lmingw32
-src_libdrizzle_redux_la_LIBADD+= -lws2_32
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LIBADD+= -lmingw32
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LIBADD+= -lws2_32
 endif
 
-src_libdrizzle_redux_la_SOURCES+= src/binlog.cc
-src_libdrizzle_redux_la_SOURCES+= src/command.cc
-src_libdrizzle_redux_la_SOURCES+= src/conn_uds.cc
-src_libdrizzle_redux_la_SOURCES+= src/error.cc
-src_libdrizzle_redux_la_SOURCES+= src/handshake.cc
-src_libdrizzle_redux_la_SOURCES+= src/query.cc
-src_libdrizzle_redux_la_SOURCES+= src/row.cc
-src_libdrizzle_redux_la_SOURCES+= src/ssl.cc
-src_libdrizzle_redux_la_SOURCES+= src/column.cc
-src_libdrizzle_redux_la_SOURCES+= src/conn.cc
-src_libdrizzle_redux_la_SOURCES+= src/drizzle.cc
-src_libdrizzle_redux_la_SOURCES+= src/field.cc
-src_libdrizzle_redux_la_SOURCES+= src/pack.cc
-src_libdrizzle_redux_la_SOURCES+= src/poll.cc
-src_libdrizzle_redux_la_SOURCES+= src/result.cc
-src_libdrizzle_redux_la_SOURCES+= src/sha1.cc
-src_libdrizzle_redux_la_SOURCES+= src/state.cc
-src_libdrizzle_redux_la_SOURCES+= src/statement.cc
-src_libdrizzle_redux_la_SOURCES+= src/statement_param.cc
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_SOURCES+= src/binlog.cc	\
+	src/command.cc	\
+	src/conn_uds.cc \
+	src/error.cc	\
+	src/handshake.cc \
+	src/query.cc	\
+	src/row.cc		\
+	src/ssl.cc		\
+	src/column.cc	\
+	src/conn.cc		\
+	src/drizzle.cc	\
+	src/field.cc	\
+	src/pack.cc		\
+	src/poll.cc		\
+	src/result.cc	\
+	src/sha1.cc		\
+	src/state.cc	\
+	src/statement.cc \
+	src/statement_param.cc
 
-src_libdrizzle_redux_la_LDFLAGS+= -version-info ${LIBDRIZZLE_LIBRARY_VERSION}
+src_libdrizzle_redux@LIBDRIZZLE_MAJOR@_la_LDFLAGS+= -version-info ${LIBDRIZZLE_LIBRARY_VERSION}

--- a/tests/unit/include.am
+++ b/tests/unit/include.am
@@ -8,7 +8,7 @@
 noinst_HEADERS+= tests/unit/common.h
 
 tests_unit_binlog_SOURCES= tests/unit/binlog.cc tests/unit/common.c
-tests_unit_binlog_LDADD= src/libdrizzle-redux.la
+tests_unit_binlog_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 check_PROGRAMS+= tests/unit/binlog
 noinst_PROGRAMS+= tests/unit/binlog
 
@@ -22,7 +22,7 @@ check-binlog: tests/unit/binlog
 	tests/unit/binlog
 
 tests_unit_event_callback_SOURCES= tests/unit/event_callback.c
-tests_unit_event_callback_LDADD= src/libdrizzle-redux.la
+tests_unit_event_callback_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_event_callback_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/event_callback
 noinst_PROGRAMS+= tests/unit/event_callback
@@ -34,25 +34,25 @@ check-event_callback: tests/unit/event_callback
 	tests/unit/event_callback
 
 tests_unit_escape_SOURCES= tests/unit/escape.c
-tests_unit_escape_LDADD= src/libdrizzle-redux.la
+tests_unit_escape_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_escape_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/escape
 noinst_PROGRAMS+= tests/unit/escape
 
 tests_unit_insert_id_SOURCES= tests/unit/insert_id.c
-tests_unit_insert_id_LDADD= src/libdrizzle-redux.la
+tests_unit_insert_id_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_insert_id_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/insert_id
 noinst_PROGRAMS+= tests/unit/insert_id
 
 tests_unit_query_SOURCES= tests/unit/query.c
-tests_unit_query_LDADD= src/libdrizzle-redux.la
+tests_unit_query_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_query_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/query
 noinst_PROGRAMS+= tests/unit/query
 
 tests_unit_column_SOURCES= tests/unit/column.c tests/unit/common.c
-tests_unit_column_LDADD= src/libdrizzle-redux.la
+tests_unit_column_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_column_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/column
 noinst_PROGRAMS+= tests/unit/column
@@ -67,43 +67,43 @@ check-column: tests/unit/column
 	tests/unit/column
 
 tests_unit_numbers_SOURCES= tests/unit/numbers.c tests/unit/common.c
-tests_unit_numbers_LDADD= src/libdrizzle-redux.la
+tests_unit_numbers_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 tests_unit_numbers_LDADD+= -lm
 nodist_EXTRA_tests_unit_numbers_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/numbers
 noinst_PROGRAMS+= tests/unit/numbers
 
 tests_unit_datetypes_SOURCES= tests/unit/datetypes.c tests/unit/common.c
-tests_unit_datetypes_LDADD= src/libdrizzle-redux.la
+tests_unit_datetypes_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_datetypes_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/datetypes
 noinst_PROGRAMS+= tests/unit/datetypes
 
 tests_unit_nulls_SOURCES= tests/unit/nulls.c tests/unit/common.c
-tests_unit_nulls_LDADD= src/libdrizzle-redux.la
+tests_unit_nulls_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_nulls_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/nulls
 noinst_PROGRAMS+= tests/unit/nulls
 
 tests_unit_row_SOURCES= tests/unit/row.c
-tests_unit_row_LDADD= src/libdrizzle-redux.la
+tests_unit_row_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_row_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/row
 noinst_PROGRAMS+= tests/unit/row
 
 tests_unit_version_SOURCES= tests/unit/version.c
-tests_unit_version_LDADD= src/libdrizzle-redux.la
+tests_unit_version_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_version_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/version
 noinst_PROGRAMS+= tests/unit/version
 
 tests_unit_version_cxx_SOURCES= tests/unit/version_cxx.cc
-tests_unit_version_cxx_LDADD= src/libdrizzle-redux.la
+tests_unit_version_cxx_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 check_PROGRAMS+= tests/unit/version_cxx
 noinst_PROGRAMS+= tests/unit/version_cxx
 
 tests_unit_connect_SOURCES= tests/unit/connect.c
-tests_unit_connect_LDADD= src/libdrizzle-redux.la
+tests_unit_connect_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_connect_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/connect
 noinst_PROGRAMS+= tests/unit/connect
@@ -118,31 +118,31 @@ check-connect: tests/unit/connect
 	tests/unit/connect
 
 tests_unit_connect_uds_SOURCES= tests/unit/connect_uds.c tests/unit/common.c
-tests_unit_connect_uds_LDADD= src/libdrizzle-redux.la
+tests_unit_connect_uds_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_connect_uds_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/connect_uds
 noinst_PROGRAMS+= tests/unit/connect_uds
 
 tests_unit_unbuffered_query_SOURCES= tests/unit/unbuffered_query.c
-tests_unit_unbuffered_query_LDADD= src/libdrizzle-redux.la
+tests_unit_unbuffered_query_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_unbuffered_query_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/unbuffered_query
 noinst_PROGRAMS+= tests/unit/unbuffered_query
 
 tests_unit_statement_SOURCES= tests/unit/statement.c
-tests_unit_statement_LDADD= src/libdrizzle-redux.la
+tests_unit_statement_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_statement_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/statement
 noinst_PROGRAMS+= tests/unit/statement
 
 tests_unit_statement_char_SOURCES= tests/unit/statement_char.c
-tests_unit_statement_char_LDADD= src/libdrizzle-redux.la
+tests_unit_statement_char_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_statement_char_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/statement_char
 noinst_PROGRAMS+= tests/unit/statement_char
 
 tests_unit_statement_nulls_SOURCES= tests/unit/statement_nulls.c tests/unit/common.c
-tests_unit_statement_nulls_LDADD= src/libdrizzle-redux.la
+tests_unit_statement_nulls_LDADD= src/libdrizzle-redux@LIBDRIZZLE_MAJOR@.la
 nodist_EXTRA_tests_unit_statement_nulls_SOURCES = dummy.cxx
 check_PROGRAMS+= tests/unit/statement_nulls
 noinst_PROGRAMS+= tests/unit/statement_nulls


### PR DESCRIPTION
The previous attempt to do so (#150) only modified the package name and binary name after the fact.
However, when generating shared library, a special ELF field (DT_SONAME) is written, which includes the binary's name.
When linking, this field (DT_SONAME) is used to populate the ELF field DT_NEEDED of the binary,
which is later used by the dynamic loader (ld.so) to load binaries on demand.
As the previous attempt was moving the file, DT_NEEDED was still populated with libdrizzle-redux,
but ld.so couldn't find it in the file system, so the binary wouldn't run.

For further reference, https://autotools.io/libtool/version.html can be used as a reference (see '4.3. Multiple libraries versions').

Note that the major version number is now applied to AC_INIT directly instead of after-the-fact,
as `AC_INIT` requires literals to be used, as it can be expanded multiple times, early on.

This is still WIP, as I need to fix the deb generation script. Will do on Monday.