### PR TITLE
Bump version to v6.0.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 # Use and distribution licensed under the BSD license.  See
 # the COPYING file in this directory for full text.
 
-AC_INIT([libdrizzle-redux6],[6.0.2],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux6],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
+AC_INIT([libdrizzle-redux6],[6.0.3],[https://github.com/sociomantic-tsunami/libdrizzle-redux/issues],[libdrizzle-redux6],[https://github.com/sociomantic-tsunami/libdrizzle-redux])
 
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -54,7 +54,7 @@ AC_CONFIG_SRCDIR([src/drizzle.cc])
 # (§) The explanation is taken from this blogpost:
 # http://blog.asleson.org/index.php/2014/07/08/libtool-library-versioning-version-info-currentrevisionage/
 #
-LIBDRIZZLE_LIBRARY_VERSION=13:2:0
+LIBDRIZZLE_LIBRARY_VERSION=13:3:0
 #                         | | |
 #                  +------+ | +---+
 #                  |        |     |

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -93,6 +93,10 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/%{name}/libdrizzle-redux/visibility.h
 
 %changelog
+* Tue May 23 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> v6.0.3
+- Correctly set the SONAME for libdrizzle-redux6 (2017-05-23)
+- Fix printf usage in deb/build (2017-05-23)
+
 * Fri May 12 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> v6.0.2
 - Add unittest for prepared statement with buffering (2017-05-10)
 - Bugfix: skip NULL fields when reading from MySQL (2017-05-10)


### PR DESCRIPTION
New ABI version 13.0.3

Use v6.0.3 in the description for how to link the
library