### PR TITLE
Fix invalid parsing of MYSQL_PORT env variable

### DIFF
--- a/tests/unit/common.c
+++ b/tests/unit/common.c
@@ -63,7 +63,7 @@ void set_up_connection(void)
   ASSERT_NULL_(con, "con opened twice?");
 
   con = drizzle_create(getenv("MYSQL_SERVER"),
-                       getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                       getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                             : DRIZZLE_DEFAULT_TCP_PORT,
                        getenv("MYSQL_USER"), getenv("MYSQL_PASSWORD"),
                        getenv("MYSQL_SCHEMA"), 0);

--- a/tests/unit/connect.c
+++ b/tests/unit/connect.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
   drizzle_socket_set_options(opts, 10, 5, 3, 3);
 
   drizzle_st *con= drizzle_create(getenv("MYSQL_SERVER"),
-                                  getenv("MYSQL_PORT") ? atoi("MYSQL_PORT") 
+                                  getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                        : DRIZZLE_DEFAULT_TCP_PORT,
                                   getenv("MYSQL_USER"),
                                   getenv("MYSQL_PASSWORD"),

--- a/tests/unit/event_callback.c
+++ b/tests/unit/event_callback.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
   int cxt_b = 0;
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),

--- a/tests/unit/insert_id.c
+++ b/tests/unit/insert_id.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
   (void)argv;
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),

--- a/tests/unit/nulls.c
+++ b/tests/unit/nulls.c
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 #endif
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),

--- a/tests/unit/query.c
+++ b/tests/unit/query.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
   int num_fields;
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),

--- a/tests/unit/row.c
+++ b/tests/unit/row.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   int num_fields;
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),

--- a/tests/unit/statement.c
+++ b/tests/unit/statement.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
   ASSERT_EQ(UINT64_MAX, drizzle_stmt_row_count(stmt));
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),

--- a/tests/unit/statement_char.c
+++ b/tests/unit/statement_char.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
   drizzle_stmt_st *stmt;
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),

--- a/tests/unit/unbuffered_query.c
+++ b/tests/unit/unbuffered_query.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
   int num_fields;
 
   drizzle_st *con = drizzle_create(getenv("MYSQL_SERVER"),
-                                   getenv("MYSQL_PORT") ? atoi("MYSQL_PORT")
+                                   getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                                         : DRIZZLE_DEFAULT_TCP_PORT,
                                    getenv("MYSQL_USER"),
                                    getenv("MYSQL_PASSWORD"),


### PR DESCRIPTION
Fixes a bug where the env variable MYSQL_PORT used
as connection parameter in the unittests was checked
for but not read correctly.