### PR TITLE
Use beaver to upload Debian packages to bintray

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "beaver"]
+	path = beaver
+	url = https://github.com/sociomantic-tsunami/beaver.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,11 @@ env:
 
 before_install:
   - gem install fpm
+  - if [[ -n "$TRAVIS_TAG" ]]; then
+        curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
+        chmod a+x /tmp/jfrog ;
+        sudo cp /tmp/jfrog /usr/local/bin/jfrog ;
+      fi
   - mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('')"
 
 ## This script runs before the compiling
@@ -63,4 +68,15 @@ script:
   - make
   - make check
   - make deb
+
+# Deploy debian packages to bintray
+deploy:
+    provider: script
+    script: beaver bintray upload -N pkg/deb/*.deb
+    skip_cleanup: true
+    on:
+        tags: true
+        condition: >
+            "$TRAVIS_OS_NAME" = "linux" -a
+            "$CC" = "gcc"
 


### PR DESCRIPTION
This repo is quite different from other Sociomantic repos, so for now
I'm just using beaver to upload the packages.

I wonder if we should just keep this repo independent from other
Sociomantic infrastructure and copy the beaver script to upload files
via jfrog here (or just call jfrog in a custom script).

In any case, we need to have packages available via an apt repo.