### PR TITLE
deb: Don't set architecture to all

### DIFF
--- a/deb/build
+++ b/deb/build
@@ -46,7 +46,6 @@ genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 cp $so_libname.$libversion $so_libname.$libversion.full
 strip  $so_libname.$libversion
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
-    --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
     --url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
@@ -70,7 +69,6 @@ build_id=`readelf -n install/usr/lib/libdrizzle-redux.so.$libversion | \
 debug_file=`printf $build_id | cut -b1-2`/`printf $build_id | cut -b3-`.debug
 objcopy --only-keep-debug $so_libname.$libversion.full $so_libname.$libversion.debug
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
-    --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
     --url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \
@@ -85,7 +83,6 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 pkgname=libdrizzle-redux-dev
 genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
-    --architecture all \
     --maintainer "$pkgmaint" \
     --description "Simplified API to MySQL databases" \
     --url 'https://github.com/sociomantic-tsunami/libdrizzle-redux' \


### PR DESCRIPTION
All is only for packages that ship cross-platform data files or scripts that run in multiple-architectures, etc. But all packages for libdrizzle-redux contains binary files that only work in the current architecture, so we must let fpm to use the current arch instead.