### PR TITLE
Bug: Fix errors in rpm/spec.in file

### DIFF
--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -93,7 +93,7 @@ mkdir -p $RPM_BUILD_ROOT/
 %{_includedir}/%{name}/libdrizzle-redux/visibility.h
 
 %changelog
-* Tue May 31 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> - 6.0.4
+* Wed May 31 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> - 6.0.4
 - Fix invalid parsing of MYSQL_PORT env variable (2017-05-28)
 
 * Tue May 23 2017 Andreas Bok Andersen <andreas.bok@sociomantic.com> v6.0.3

--- a/rpm/spec.in
+++ b/rpm/spec.in
@@ -45,7 +45,7 @@ you will need to install %{name}-devel.
 # rename the directory to `include/libdrizzle-redux`
 if test -d %{rpm_include_path}
 then
-    tmp_include_path=$RPM_BUILD_ROOT/usr/include/%{header_install_path}
+    tmp_include_path=$RPM_BUILD_ROOT/usr/include/%{name}
     mkdir -p $tmp_include_path
     mv %{rpm_include_path} ${tmp_include_path}/
 fi


### PR DESCRIPTION
#Bogus date for v6.0.4 release

Bugfix: Use %{name} in lieu of %{header_install_path}
The variable `header_install_path` was uninitialized
and thus resulted in rpmbuild not being able to
find the header files.
