### PR TITLE
Freeze fpm to version v1.8.1 for travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
 #    packages:
 
 before_install:
-  - gem install fpm
+  - gem install fpm -v 1.8.1
   - if [[ -n "$TRAVIS_TAG" ]]; then
         curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
         chmod a+x /tmp/jfrog ;


### PR DESCRIPTION
Use fpm version v1.8.1 on travis to handle issue
where symlinks were not copied to the packing staging
directory when using source=dest/ syntax

Can be removed when the bugfix in
https://github.com/jordansissel/fpm/pull/1399 has been
merged and released
