### PR TITLE
Fix crash when SQL gives a single NULL

### DIFF
--- a/libdrizzle/field.cc
+++ b/libdrizzle/field.cc
@@ -66,6 +66,16 @@ drizzle_field_t drizzle_field_read(drizzle_result_st *result, uint64_t *offset,
     return 0;
   }
 
+  if (result->binary_rows && (result->field_current == 0))
+  {
+    result->push_state(drizzle_state_binary_null_read);
+    *ret_ptr= drizzle_state_loop(result->con);
+    if (*ret_ptr != DRIZZLE_RETURN_OK)
+    {
+      return 0;
+    }
+  }
+
   if (result->has_state())
   {
     if (result->field_current == (result->column_count - result->null_bitcount))
@@ -82,11 +92,6 @@ drizzle_field_t drizzle_field_read(drizzle_result_st *result, uint64_t *offset,
     {
       result->push_state(drizzle_state_field_read);
     }
-  }
-
-  if (result->binary_rows && (result->field_current == 0))
-  {
-    result->push_state(drizzle_state_binary_null_read);
   }
 
   *ret_ptr= drizzle_state_loop(result->con);

--- a/tests/unit/nulls.c
+++ b/tests/unit/nulls.c
@@ -146,6 +146,23 @@ int main(int argc, char *argv[])
   CHECKED_QUERY(querybuf);
 
 #ifdef TEST_PREPARED_STATEMENTS
+  strcpy(querybuf, "SELECT NULL");
+  sth = drizzle_stmt_prepare(con, querybuf, strlen(querybuf), &driz_ret);
+
+  ASSERT_EQ_(driz_ret, DRIZZLE_RETURN_OK, "Error (%s): %s, preparing \"%s\"",
+             drizzle_strerror(driz_ret), drizzle_error(con), querybuf);
+
+  driz_ret = drizzle_stmt_execute(sth);
+  ASSERT_EQ_(driz_ret, DRIZZLE_RETURN_OK, "Error (%s): %s, executing \"%s\"",
+             drizzle_strerror(driz_ret), drizzle_error(con), querybuf);
+
+  driz_ret = drizzle_stmt_buffer(sth);
+  ASSERT_EQ_(driz_ret, DRIZZLE_RETURN_OK,
+             "Error (%s): %s, buffering result from query \"%s\"",
+             drizzle_strerror(driz_ret), drizzle_error(con), querybuf);
+
+  ASSERT_EQ(drizzle_stmt_close(sth), DRIZZLE_RETURN_OK);
+
   strcpy(querybuf, "INSERT INTO test_nulls.t1 VALUES (?,?,?,?,?,?,?,?,?,?,?)");
   sth = drizzle_stmt_prepare(con, querybuf, strlen(querybuf), &driz_ret);
   ASSERT_EQ_(driz_ret, DRIZZLE_RETURN_OK, "Error (%s): %s, preparing \"%s\"",


### PR DESCRIPTION
`libdrizzle-redux` would trigger a crash when SQL statements gives only `NULL` fields, this is caused by not handling fields properly in function `drizzle_field_read`.

We can test this by a simple SQL statement:
```sql
SELECT NULL
```

In `drizzle_field_read`(`libdrizzle/field.cc`):
```cpp
/* line 69 ~ 92 */
  if (result->has_state())
  {
    if (result->field_current == (result->column_count - result->null_bitcount))
    {
      *ret_ptr= DRIZZLE_RETURN_ROW_END;
      return NULL;
    }

    if (result->binary_rows)
    {
      result->push_state(drizzle_state_binary_field_read);
    }
    else
    {
      result->push_state(drizzle_state_field_read);
    }
  }

  if (result->binary_rows && (result->field_current == 0))
  {
    result->push_state(drizzle_state_binary_null_read);
  }

  *ret_ptr= drizzle_state_loop(result->con);
```

Here we can see, when the first time `drizzle_field_read` been called, it pushes 2 states into the state machine, which are `drizzle_state_binary_null_read` for handling `NULL` fields, and `drizzle_state[_binary]_field_read` for handling non-`NULL` fields.

If the SQL statement gives only `NULL` fields, the `drizzle_state[_binary]_field_read` state should **NOT** be pushed into state machine, since there are no actual fields to be read.

This patch fixes this problem by forcing a `drizzle_state_binary_null_read` before handling non-`NULL` fields, this enables the `ROW_END` checking before pushing `drizzle_state[_binary]_field_read` into state machine, thus solves the problem.

I will construct a simple test program to help solving this problem.