### PR TITLE
Bugfix: invalid syntax in ASSERT_NOT_NULL macro

### DIFF
--- a/yatl/lite.h
+++ b/yatl/lite.h
@@ -150,7 +150,7 @@ do \
 do \
 { \
   if ((__expression) == NULL) { \
-    fprintf(stderr, "\n%s:%d: %s Assertion '%s' == NULL\n", __FILE__, __LINE__, __PRETTY_FUNCTION__, #__expression,);\
+    fprintf(stderr, "\n%s:%d: %s Assertion '%s' == NULL\n", __FILE__, __LINE__, __PRETTY_FUNCTION__, #__expression);\
     exit(EXIT_FAILURE); \
   } \
 } while (0)


### PR DESCRIPTION
Remove spurious ',' at the end of the fprintf arg
list