### PR TITLE
Check for NULL params in drizzle_binlog_init function

### DIFF
--- a/libdrizzle/binlog.cc
+++ b/libdrizzle/binlog.cc
@@ -51,6 +51,16 @@ drizzle_binlog_st *drizzle_binlog_init(drizzle_st *con,
   {
     return NULL;
   }
+  else if (binlog_fn == NULL)
+  {
+    drizzle_set_error(con, __func__, "binlog event callback function is NULL");
+    return NULL;
+  }
+  else if (error_fn == NULL)
+  {
+    drizzle_set_error(con, __func__, "binlog error callback function is NULL");
+    return NULL;
+  }
 
   drizzle_binlog_st *binlog= new (std::nothrow) drizzle_binlog_st;
   if (binlog == NULL)

--- a/tests/unit/binlog.cc
+++ b/tests/unit/binlog.cc
@@ -77,10 +77,20 @@ int main(int argc, char *argv[])
 
   set_up_connection();
 
+  binlog = drizzle_binlog_init(NULL, binlog_event, binlog_error, NULL, true);
+  ASSERT_NULL_(binlog, "Drizzle connection is null");
+
+  binlog = drizzle_binlog_init(con, NULL, binlog_error, NULL, true);
+  ASSERT_NULL_(binlog, "Binlog event callback function is NULL");
+
+  binlog = drizzle_binlog_init(con, binlog_event, NULL, NULL, true);
+  ASSERT_NULL_(binlog, "Binlog error callback function is NULL");
+
   char *binlog_file;
   drizzle_binlog_get_filename(con, &binlog_file, -1);
 
   binlog = drizzle_binlog_init(con, binlog_event, binlog_error, NULL, true);
+  ASSERT_NOT_NULL_(binlog, "Binlog object creation error");
   ret = drizzle_binlog_start(binlog, 0, binlog_file, 0);
 
   SKIP_IF_(ret == DRIZZLE_RETURN_ERROR_CODE, "Binlog is not open?: %s(%s)",


### PR DESCRIPTION
It wouldn't make sense to use the binlog without the callbacks. 
But no check is made as to whether the  event and error callback functions are not **NULL** before they are invoked. 

Add checks to the binlog unittest for passing NULL arguments to drizzle_binlog_init