### PR TITLE
Bugfix: Set env variable MYSQL_PASSWORD=pass in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER andreas-bok-sociomantic <andreas.bok@sociomantic.com>
 # Set environment variables
 ENV MYSQL_USER=user \
     MYSQL_PASSWORD=pass \
-    MYSQL_ROOT_PASSWORD='' \
+    MYSQL_ROOT_PASSWORD=pass \
     MYSQL_SERVER=127.0.0.1 \
     MYSQL_PORT=3306 \
     MYSQL_DATABASE=test \


### PR DESCRIPTION
The travis build failed for RPM which builds the library in a centos docker container

The MYSQL_PASSWORD was previously set to an empty string as '' which was not allowed.