### PR TITLE
Make binlog unittest compile with GCC

### DIFF
--- a/tests/unit/binlog.c
+++ b/tests/unit/binlog.c
@@ -38,11 +38,10 @@
 #include <libdrizzle-5.1/libdrizzle.h>
 #include <yatl/lite.h>
 
-#include <cstdio>
-#include <cstdlib>
 
 #include "tests/unit/common.h"
 
+void binlog_error(drizzle_return_t ret, drizzle_st *connection, void *context);
 void binlog_error(drizzle_return_t ret, drizzle_st *connection, void *context)
 {
   (void)context;
@@ -50,6 +49,7 @@ void binlog_error(drizzle_return_t ret, drizzle_st *connection, void *context)
              drizzle_strerror(ret));
 }
 
+void binlog_event(drizzle_binlog_event_st *event, void *context);
 void binlog_event(drizzle_binlog_event_st *event, void *context)
 {
   (void)context;

--- a/tests/unit/include.am
+++ b/tests/unit/include.am
@@ -7,7 +7,7 @@
 
 noinst_HEADERS+= tests/unit/common.h
 
-tests_unit_binlog_SOURCES= tests/unit/binlog.cc tests/unit/common.c
+tests_unit_binlog_SOURCES= tests/unit/binlog.c tests/unit/common.c
 tests_unit_binlog_LDADD= libdrizzle/libdrizzle-redux.la
 check_PROGRAMS+= tests/unit/binlog
 noinst_PROGRAMS+= tests/unit/binlog


### PR DESCRIPTION
Fixes issue where binlog unittest was compiled as C++ possibly breaking the C API.

- Remove C++ imports
- Rename the file to binlog.c
- Declare prototypes for callback functions