### PR TITLE
Bugfix: Let callbacks be NULL with CLIENT as socket owner

### DIFF
--- a/tests/unit/binlog.c
+++ b/tests/unit/binlog.c
@@ -75,16 +75,29 @@ int main(int argc, char *argv[])
   drizzle_binlog_st *binlog;
   drizzle_return_t ret;
 
+  // Test initialization of binlog with socket owner as client
+  opts = drizzle_options_create();
+  drizzle_options_set_socket_owner(opts, DRIZZLE_SOCKET_OWNER_CLIENT);
+
   set_up_connection();
 
   binlog = drizzle_binlog_init(NULL, binlog_event, binlog_error, NULL, true);
   ASSERT_NULL_(binlog, "Drizzle connection is null");
 
   binlog = drizzle_binlog_init(con, NULL, binlog_error, NULL, true);
-  ASSERT_NULL_(binlog, "Binlog event callback function is NULL");
+  ASSERT_NOT_NULL_(binlog, "Binlog event callback function is NULL");
 
   binlog = drizzle_binlog_init(con, binlog_event, NULL, NULL, true);
-  ASSERT_NULL_(binlog, "Binlog error callback function is NULL");
+  ASSERT_NOT_NULL_(binlog, "Binlog error callback function is NULL");
+
+  // Quit the drizzle connection and test binlog initialization with socket
+  // owner as native
+  close_connection_on_exit();
+
+  opts = drizzle_options_create();
+  drizzle_options_set_socket_owner(opts, DRIZZLE_SOCKET_OWNER_NATIVE);
+
+  set_up_connection();
 
   char *binlog_file;
   drizzle_binlog_get_filename(con, &binlog_file, -1);

--- a/tests/unit/common.c
+++ b/tests/unit/common.c
@@ -39,11 +39,17 @@
 #include <yatl/lite.h>
 
 drizzle_st *con = NULL;
+drizzle_options_st *opts = NULL;
 
 void close_connection_on_exit(void)
 {
   if (con == NULL) {
     return;
+  }
+
+  if (opts != NULL)
+  {
+    drizzle_options_destroy(opts);
   }
 
   drizzle_return_t ret = drizzle_quit(con);
@@ -66,7 +72,7 @@ void set_up_connection(void)
                        getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
                                             : DRIZZLE_DEFAULT_TCP_PORT,
                        getenv("MYSQL_USER"), getenv("MYSQL_PASSWORD"),
-                       getenv("MYSQL_SCHEMA"), 0);
+                       getenv("MYSQL_SCHEMA"), opts);
   ASSERT_NOT_NULL_(con, "Drizzle connection object creation error");
 
   verbosity = getenv("DRIZZLE_TEST_VERBOSE");

--- a/tests/unit/common.h
+++ b/tests/unit/common.h
@@ -53,6 +53,7 @@ extern "C" {
 #endif
 
 extern drizzle_st *con;
+extern drizzle_options_st *opts;
 
 /* Common connection setup used by the unit tests.
  */


### PR DESCRIPTION
If the client handles parsing of binlog data, callback functions passed to `drizzle_binlog_init` can be **NULL**

Add checks in `binlog.cc` so callbacks are only invoked if they are **NOT NULL**

Update binlog unittest to validate this