### PR TITLE
Make deploy step depend on repo slug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
 
 before_install:
   - gem install fpm -v 1.8.1
-  - if [[ -n "$TRAVIS_TAG" ]]; then
+  - if [[ -n "$TRAVIS_TAG" && $REPO_SLUG == "sociomantic-tsunami/libdrizzle-redux" ]]; then
       curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
       chmod a+x /tmp/jfrog ;
       sudo cp /tmp/jfrog /usr/local/bin/jfrog ;
@@ -79,4 +79,5 @@ deploy:
     skip_cleanup: true
     on:
         tags: true
+        repo: sociomantic-tsunami/libdrizzle-redux
         condition: $TRAVIS_OS_NAME = 'linux' && $CC = 'gcc'


### PR DESCRIPTION
Check repo slug in `before_install` and `deploy` sections so `jfrog` install and deployment are only performed for tagged builds in `sociomantic-tsunami/libdrizzle-redux`