### PR TITLE
Add unittests for invalid connection parameters

### DIFF
--- a/tests/unit/connect.c
+++ b/tests/unit/connect.c
@@ -45,6 +45,40 @@
 drizzle_st *con;
 drizzle_return_t driz_ret;
 
+/**
+ * Test connection errors
+ *
+ * Creates a drizzle struct with the specified connection settings. Performs a
+ * call to drizzle_connect and afterwards tests the expected return value and
+ * error string with the actual values
+
+ * @param[in]  host            host
+ * @param[in]  port            port
+ * @param[in]  user            user
+ * @param[in]  password        password
+ * @param[in]  db              database
+ * @param[in]  ret_expected    expected return value
+ * @param[in]  error_expected  expected error string
+ * @param[in]  timeout         connection timeout
+ */
+void test_connection_error(const char *host, in_port_t port,
+                           const char *user, const char *password,
+                           const char *db, drizzle_return_t ret_expected,
+                           const char *error_expected, int timeout);
+
+void test_connection_error(const char *host, in_port_t port,
+                           const char *user, const char *password,
+                           const char *db, drizzle_return_t ret_expected,
+                           const char *error_expected, int timeout)
+{
+  con = drizzle_create(host, port, user, password, db, NULL);
+  drizzle_set_timeout(con, timeout);
+  driz_ret = drizzle_connect(con);
+  ASSERT_EQ(driz_ret, ret_expected);
+  ASSERT_STREQ(drizzle_error(con), error_expected);
+  drizzle_quit(con);
+}
+
 int main(int argc, char *argv[])
 {
   (void)argc;

--- a/tests/unit/connect.c
+++ b/tests/unit/connect.c
@@ -50,15 +50,16 @@ int main(int argc, char *argv[])
   (void)argc;
   (void)argv;
 
+  const char *host = getenv("MYSQL_SERVER");
+  in_port_t port = getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
+                                        : DRIZZLE_DEFAULT_TCP_PORT;
+  const char *user = getenv("MYSQL_USER");
+  const char *pass = getenv("MYSQL_PASSWORD");
+  const char *db = getenv("MYSQL_SCHEMA");
   drizzle_options_st *opts = drizzle_options_create();
   drizzle_socket_set_options(opts, 10, 5, 3, 3);
 
-  con = drizzle_create(getenv("MYSQL_SERVER"),
-                       getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
-                                            : DRIZZLE_DEFAULT_TCP_PORT,
-                       getenv("MYSQL_USER"),
-                       getenv("MYSQL_PASSWORD"),
-                       getenv("MYSQL_SCHEMA"), opts);
+  con = drizzle_create(host, port, user, pass, db, opts);
   ASSERT_NOT_NULL_(con, "Drizzle connection object creation error");
 
   int opt_val = drizzle_socket_get_option(con, DRIZZLE_SOCKET_OPTION_TIMEOUT);


### PR DESCRIPTION
Test error string and drizzle_return_t value
for invalid host, port, user, pass, db settings

Addresses bugfix #215