### PR TITLE
Don't deploy rpm packages to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,4 +104,4 @@ deploy:
     on:
         tags: true
         repo: sociomantic-tsunami/libdrizzle-redux
-        condition: $TRAVIS_OS_NAME = 'linux' && $CC = 'gcc'
+        condition: $TRAVIS_OS_NAME = 'linux' && $CC = 'gcc' && $DIST_PACKAGE_TARGET = 'DEB'


### PR DESCRIPTION
At the moment we don't want to deploy `rpm` packages to `bintray`