### PR TITLE
travis: Fix wrong deb pkg path argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ script:
 # Deploy debian packages to bintray when building for a git tag
 deploy:
     provider: script
-    script: beaver bintray upload -N deb/*.deb
+    script: beaver bintray upload -N pkg/deb/*.deb
     skip_cleanup: true
     on:
         tags: true


### PR DESCRIPTION
On `v5.x.x` the location layout for the generated deb packages were changed. `deb/*.deb` -> `pkg/deb/*.deb`. 
Since tagged builds were created for `v5.x.x` until now, the problem with the wrong path was not discovered earlier. 