### PR TITLE
Use latest version of fpm

### DIFF
--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -34,7 +34,7 @@ before_install()
 {
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         if [[ "$DIST_PACKAGE_TARGET" == "DEB" ]]; then
-            gem install fpm -v 1.8.1
+            gem install fpm
 
             if [[ -n "$TRAVIS_TAG" && $TRAVIS_REPO_SLUG == "sociomantic-tsunami/libdrizzle-redux" ]]; then
                 curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;


### PR DESCRIPTION
The bug related to copying symlinks to the package staging directory has been fixed in fpm v1.9.3