### PR TITLE
travis: Remove outdated comment in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ services:
 #  Please note that test fails on first error as default
 #  To skip errors and fail silently set environment variable:
 #    SKIP_TEST_ON_ERROR=1
-#
-#  To speed up installation of brew formulas on osx auto update for homebrew is
-#  turned off by setting HOMEBREW_NO_AUTO_UPDATE=1
 env:
   global:
     - MYSQL_SERVER=127.0.0.1


### PR DESCRIPTION
The comment should have been removed in
15d0a3c4c4344b3de361f82033f3819d6dd3296f