### PR TITLE
Make path to generated deb packages version independent 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,6 @@ maintainer-clean-local:
 	find . -type f -name '*~' -exec rm -f '{}' \;
 	-rm -f @PACKAGE@-*.tar.gz
 	-rm -f ./pkg/rpm/@PACKAGE@-*.rpm
-	-rm -f ./pkg/deb/@PACKAGE@-*.deb
+	-rm -f ./build/pkg/deb/@PACKAGE@-*.deb
 
 dist_bin_SCRIPTS+= @GENERIC_CONFIG@

--- a/pkg/deb/build
+++ b/pkg/deb/build
@@ -25,6 +25,7 @@ description="Simple Asynchronous C API to MySQL databases"
 url="https://github.com/sociomantic-tsunami/libdrizzle-redux"
 vendor="Sociomantic Labs GmbH"
 license="Simplified BSD License"
+package="$1"
 
 pkgname=libdrizzle-redux
 so_filename=libdrizzle-redux.so
@@ -50,6 +51,7 @@ genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 cp $so_libname.$libversion $so_libname.$libversion.full
 strip  $so_libname.$libversion
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
+    --package "$package" \
     --maintainer "$pkgmaint" \
     --description "$description" \
     --url "$url" \
@@ -73,6 +75,7 @@ build_id=`readelf -n install/usr/lib/libdrizzle-redux.so.$libversion | \
 debug_file=`printf $build_id | cut -b1-2`/`printf $build_id | cut -b3-`.debug
 objcopy --only-keep-debug $so_libname.$libversion.full $so_libname.$libversion.debug
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
+    --package "$package" \
     --maintainer "$pkgmaint" \
     --description "$description" \
     --url "$url" \
@@ -87,6 +90,7 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 pkgname=libdrizzle-redux-dev
 genchangelog "$pkgname" "$pkgversion" "$pkgmaint" > "$changelog"
 fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
+    --package "$package" \
     --maintainer "$pkgmaint" \
     --description "$description" \
     --url "$url" \

--- a/pkg/deb/include.am
+++ b/pkg/deb/include.am
@@ -9,7 +9,7 @@
 deb: clean-deb
 	./configure --prefix=/usr
 	$(MAKE) DESTDIR=${abs_builddir}/pkg/deb/install install
-	pkg/deb/build
+	pkg/deb/build "${abs_top_srcdir}/build/pkg/deb"
 
 release-deb:
 	@read -p "Enter version (previous: $$(git describe --abbrev=0)): " version; \
@@ -23,4 +23,4 @@ release-deb:
 	git tag -a -m "$$msg" $$version
 
 clean-deb:
-	-rm -rf pkg/deb/*.deb pkg/deb/install
+	-rm -rf ./build/pkg/deb/*.deb ./pkg/deb/install


### PR DESCRIPTION
Fixes an issue where the location of generated deb 
packages depended on the version of the library