### PR TITLE
Enable unittests to not return EXIT_FAILURE on SKIP

### DIFF
--- a/yatl/lite.h
+++ b/yatl/lite.h
@@ -59,7 +59,9 @@
 #endif
 
 #ifndef EXIT_SKIP
- #define EXIT_SKIP SKIP_TEST_ON_ERROR ? 77 : EXIT_FAILURE
+ #define EXIT_SKIP (!getenv("DRIZZLE_TEST_EXIT_ERROR_ON_SKIP") ? \
+                    EXIT_FAILURE : atoi(getenv("DRIZZLE_TEST_EXIT_ERROR_ON_SKIP")) ? \
+                    EXIT_FAILURE : 77)
 #endif
 
 static inline bool valgrind_is_caller(void)


### PR DESCRIPTION
Add env var DRIZZLE_TEST_EXIT_ERROR_ON_SKIP
to set whether a unittest should return EXIT_FAILURE
when it is skipped