### PR TITLE
Use docker-compose on travis for linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,20 @@ language: cpp
 ## Enable cache for dependencies and directories
 cache: ccache
 
-## Enable sudo
+## Enable sudo (set explicitly although environment's with docker is sudo
+#  enabled by default
 sudo: required
 
 ## Operating Systems to use for builds
 os:
   - linux
 
-## Compilers to use for builds
-compiler:
-  - gcc
-  - clang
-
 ## Ensures the virtualization environment runs as Ubuntu 14.04 Trusty
 dist: trusty
-
 group: edge
 
 ## Services started on the build environment
 services:
- - mysql
  - docker
 
 ## Environment variables
@@ -31,58 +25,55 @@ services:
 #  build matrix, i.e. every build configuration.
 #  In turn, variables defined in the 'matrix' section each triggers a separate
 #  build.
-#
-#  Please note that test fails on first error as default
-#  To skip errors and fail silently set environment variable:
-#    SKIP_TEST_ON_ERROR=1
-#
-#  To speed up installation of brew formulas on osx auto update for homebrew is
-#  turned off by setting HOMEBREW_NO_AUTO_UPDATE=1
 env:
   global:
-    - MYSQL_SERVER=127.0.0.1
+    - COMPILER_VERSION=
+    - DEPLOY_PACKAGE=false
+    - DIST_NAME=ubuntu
+    - DIST_VERSION=xenial
+    - DOCKER_COMPOSE_VERSION=1.16.1
+    - DRIZZLE_TEST_EXIT_ERROR_ON_SKIP=0
+    - MAKE_TARGET=check
     - MYSQL_PASSWORD=''
-    - MYSQL_USER=root
     - MYSQL_PORT=3306
-    - DIST_PACKAGE_TARGET=DEB
-    - SKIP_TEST_ON_ERROR=0
+    - MYSQL_SERVER=127.0.0.1
+    - MYSQL_USER=root
     - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
+    - SKIP_TEST_ON_ERROR=0
   matrix:
-    - DIST_PACKAGE_TARGET=DEB
-    - DIST_PACKAGE_TARGET=RPM
+    - COMPILER_VERSION=4.9 MAKE_TARGET="$MAKE_TARGET:deb" DEPLOY_PACKAGE=true
+    - CXX=clang++ CC=clang COMPILER_VERSION=3.9
+    - DIST_NAME=centos DIST_VERSION=7 MAKE_TARGET=rpm
 
 ## Build matrix
 #
-#  The 'os', 'compiler' and 'env' settings are expanded into 3 jobs:
+#  Travis expands the environment variables into 6¹ jobs:
+#  All linux based builds are run in docker containers using docker-compose
 #
-#  | os     | compiler    | DIST_PACKAGE_TARGET |
+#  | os     | compiler    | make targets        |
 #  |--------|-------------|---------------------|
-#  | linux  | clang       | DEB                 |
-#  | linux  | gcc         | DEB                 |
-#  | linux* | gcc         | RPM                 |
+#  | linux  | clang       | check               |
+#  | linux  | gcc         | check deb           |
+#  | linux  | gcc         | rpm                 |
 #  | osx    | clang 6.1.0 |                     |
 #  | osx    | clang 7.3.0 |                     |
 #  | osx    | clang 8.1.0 |                     |
 #
 #  For osx, the compiler reported is the Apple LLVM version
 #
-#  * the RPM package is built in a docker container running centos7
+#  ¹ Due to excessive build times for osx only XCode 7.3.1 has been enabled.
 matrix:
   fast_finish: true
-  exclude:
-    - os: linux
-      compiler: clang
-      env: DIST_PACKAGE_TARGET=RPM
   include:
-    - os: osx
-      osx_image: xcode6.4
-      compiler: clang
+    # - os: osx
+    #   osx_image: xcode6.4
+    #   compiler: clang
     - os: osx
       osx_image: xcode7.3.1
       compiler: clang
-    - os: osx
-      osx_image: xcode8.3
-      compiler: clang
+    # - os: osx
+    #   osx_image: xcode8.3
+    #   compiler: clang
 
 ## Install dependencies
 before_install:
@@ -96,12 +87,14 @@ before_script:
 script:
   - ./travis_configure.sh run_tests
 
-# Deploy debian packages to bintray when building for a git tag
+## Deploy debian packages to bintray
+##
+## deb package built on ubuntu xenial with gcc
 deploy:
     provider: script
     script: beaver bintray upload -N pkg/deb/*.deb
     skip_cleanup: true
     on:
-        tags: true
-        repo: sociomantic-tsunami/libdrizzle-redux
-        condition: $TRAVIS_OS_NAME = 'linux' && $CC = 'gcc' && $DIST_PACKAGE_TARGET = 'DEB'
+        tags: true # must be a git tag
+        repo: sociomantic-tsunami/libdrizzle-redux # must be upstream
+        condition: $TRAVIS_OS_NAME = 'linux' && $DIST_NAME = 'ubuntu' && $DIST_VERSION = 'xenial' && $CC = 'gcc' && $MAKE_TARGET =~ 'deb' && $DEPLOY_PACKAGE = 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+# Configuration file to run ci tests in docker containers
+#
+# Defines a database container with MySQL and a container with the environment
+# to build libdrizzle-redux. The latter container runs either ubuntu or centos
+# depending on the travis build configuration.
+#
+# See https://docs.docker.com/compose/overview/ for more information about
+# the format of the docker compose config file
+version: '3'
+
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    env_file:
+      - ./docker/mysql.env
+    container_name: mysql-container
+    volumes:
+      - "mysql_socket:/tmp/"
+      - ./docker/mysqld_binlog.cnf:/etc/mysql/mysql.conf.d/mysqld_binlog.cnf
+
+  libdrizzle:
+    env_file:
+      - ./docker/mysql.env
+      - ./docker/libdrizzle-redux.env
+    environment:
+    # environment variables interpolated from travis
+      COMPILER_VERSION: $COMPILER_VERSION
+      MAKE_TARGET: $MAKE_TARGET
+      DIST_NAME: $DIST_NAME
+      CXX: $CXX
+      CC: $CC
+    build:
+      context: ./
+    depends_on:
+      - db
+    container_name: libdrizzle-redux-container
+    links:
+      - db:database
+    volumes:
+      - "mysql_socket:/tmp/"
+      - ./:/home/libdrizzle-redux/
+      - ./docker/container_entrypoint.sh:/usr/local/bin/container_entrypoint.sh
+    working_dir: /home/libdrizzle-redux/
+    entrypoint:
+      - container_entrypoint.sh
+
+# volume used to share mysql socket between containers
+volumes:
+  mysql_socket: {}

--- a/docker/Dockerfile.centos.7
+++ b/docker/Dockerfile.centos.7
@@ -1,34 +1,8 @@
-# Docker build file to create an image running centos7 with MySQL and build
-# tools installed
-
-FROM centos/mysql-56-centos7:latest
+# Docker build file to create an image with centos 7
+FROM centos:7
 MAINTAINER andreas-bok-sociomantic <andreas.bok@sociomantic.com>
 
-# Set environment variables
-ENV MYSQL_USER=user \
-    MYSQL_PASSWORD=pass \
-    MYSQL_ROOT_PASSWORD=pass \
-    MYSQL_SERVER=127.0.0.1 \
-    MYSQL_PORT=3306 \
-    MYSQL_DATABASE=test \
-    MYSQL_MASTER_USER=user \
-    MYSQL_MASTER_PASSWORD=pass \
-    MYSQL_BINLOG_FORMAT=ROW \
-    SKIP_TEST_ON_ERROR=0
-
-# Change user to `root` and install required packages to build libdrizzle-redux.
-USER root
-RUN yum install -y deltarpm
-RUN yum install -y rpm-build zlib-devel libtool openssl \
+# install required packages
+RUN yum install -y deltarpm && \
+yum install -y rpm-build zlib-devel libtool openssl \
     openssl-devel automake autoconf gcc-c++
-
-# Add host directory to container
-ADD ./ /home/
-
-WORKDIR /home
-
-# Change back user to default user for the image: mysql
-USER mysql
-
-# Run the MySQL server with replication enabled
-CMD [ "run-mysqld-master" ]

--- a/docker/Dockerfile.ubuntu.xenial
+++ b/docker/Dockerfile.ubuntu.xenial
@@ -1,0 +1,6 @@
+# Dockerfile for building an image with ubuntu xenial
+FROM sociomantictsunami/base
+MAINTAINER andreas-bok-sociomantic <andreas.bok@sociomantic.com>
+
+ADD docker/ubuntu_xenial_image_run.sh  /usr/local/bin/
+RUN sudo /usr/local/bin/ubuntu_xenial_image_run.sh

--- a/docker/container_entrypoint.sh
+++ b/docker/container_entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# entrypoint for the container
+
+install_dependencies()
+{
+    if [[ "$DIST_NAME" == "ubuntu" ]]; then
+        # install compiler
+        COMPILER=$CXX
+        if [[ ! -z $COMPILER_VERSION ]]; then
+            COMPILER="$CXX-$COMPILER_VERSION"
+        fi
+        apt-fast install -y $COMPILER
+    fi
+
+    if [[ "$DIST_NAME" == "centos" ]]; then
+        # install compiler
+        if [[ "$CXX" == "clang" ]]; then
+            yum install -y clang
+        fi
+    fi
+}
+
+# install dependencies
+#chmod +x /usr/local/bin/install_dependencies.sh
+install_dependencies
+
+# configure and compile the project
+# run make targets specified in env MAKE_TARGET
+if [[ ! -e ./configure ]]; then
+    autoreconf -fi
+    ./configure
+fi
+
+make ${MAKE_TARGET//:/ }

--- a/docker/docker-compose.centos.7.yml
+++ b/docker/docker-compose.centos.7.yml
@@ -1,0 +1,7 @@
+# Docker compose file to override configuration for centos based images
+version: '3'
+
+services:
+  libdrizzle:
+    build:
+      dockerfile: ./docker/Dockerfile.centos.7

--- a/docker/docker-compose.ubuntu.xenial.yml
+++ b/docker/docker-compose.ubuntu.xenial.yml
@@ -1,0 +1,7 @@
+# Docker compose file to override configuration for centos based images
+version: '3'
+
+services:
+  libdrizzle:
+    build:
+      dockerfile: ./docker/Dockerfile.ubuntu.xenial

--- a/docker/libdrizzle-redux.env
+++ b/docker/libdrizzle-redux.env
@@ -1,0 +1,10 @@
+# Docker environment variables for the container where libdrizzle-redux is
+# compiled
+# The file is used for the docker-compose.yml::env_file setting
+DRIZZLE_TEST_EXIT_ERROR_ON_SKIP=0
+MYSQL_PORT=3306
+MYSQL_SCHEMA=test
+MYSQL_SERVER=database
+MYSQL_SOCK=/tmp/mysqld.sock
+MYSQL_USER=root
+SKIP_TEST_ON_ERROR=0

--- a/docker/mysql.env
+++ b/docker/mysql.env
@@ -1,0 +1,6 @@
+# Docker environment variables for the MySQL container
+# The file is used for the docker-compose.yml::env_file setting
+MYSQL_DATABASE=test
+MYSQL_PASSWORD=pass
+MYSQL_ROOT_PASSWORD=pass
+MYSQL_USER=user

--- a/docker/mysqld_binlog.cnf
+++ b/docker/mysqld_binlog.cnf
@@ -1,0 +1,14 @@
+# Custom config file for MySQL to enable replication
+# The settings are combined with the default MySQL mysqld.cnf config file
+# See the section "Using a custom MySQL configuration file" at
+# https://hub.docker.com/_/mysql/ for more information
+
+[mysqld]
+socket                  = /tmp/mysqld.sock
+
+# Replication settings
+server-id               = 1
+log_bin                 = /var/log/mysql/mysql-bin.log
+binlog_format           = ROW
+expire_logs_days        = 10
+max_binlog_size         = 100

--- a/docker/ubuntu_xenial_image_run.sh
+++ b/docker/ubuntu_xenial_image_run.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+export DEBIAN_FRONTEND=noninteractive
+echo "# delete all the apt list files to speed up 'apt-get update' command"
+# delete all the apt list files to speed up 'apt-get update' command
+rm -rf /var/lib/apt/lists/*
+
+echo "# install apt repo for clang compiler"
+# install apt repo for clang compiler
+echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/apt/sources.list
+echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/apt/sources.list
+gpg --keyserver keyserver.ubuntu.com --recv AF4F7421
+
+echo "deb http://ppa.launchpad.net/saiarcot895/myppa/ubuntu xenial main" >> /etc/apt/sources.list
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DC058F40
+apt-get update
+
+apt-get install --no-install-recommends -y apt-fast
+# install required packages
+apt-fast -y install --no-install-recommends \
+    libssl-dev autoconf libtool make automake zlib1g-dev

--- a/tests/unit/connect.c
+++ b/tests/unit/connect.c
@@ -96,15 +96,15 @@ int main(int argc, char *argv[])
     DRIZZLE_RETURN_TIMEOUT, 3);
 
   // invalid port
-  test_connection_error("localhost", 1234, "valid_user", "valid_pass",
+  test_connection_error(host, 1234, "valid_user", "valid_pass",
     "valid_db", DRIZZLE_RETURN_COULD_NOT_CONNECT, -1);
 
   // invalid user
-  test_connection_error("localhost", port, "invalid_user", "valid_pass",
+  test_connection_error(host, port, "invalid_user", "valid_pass",
     "valid_db", DRIZZLE_RETURN_HANDSHAKE_FAILED, -1);
 
   // invalid pass
-  test_connection_error("localhost", port, "valid_user", "invalid_pass",
+  test_connection_error(host, port, "valid_user", "invalid_pass",
     "valid_db", DRIZZLE_RETURN_HANDSHAKE_FAILED, -1);
 
   // invalid schema

--- a/tests/unit/connect_uds.c
+++ b/tests/unit/connect_uds.c
@@ -50,7 +50,9 @@ int main(int argc, char *argv[])
   (void)argv;
 
   con = drizzle_create(getenv("MYSQL_SOCK"),
-                       0, getenv("MYSQL_USER"),
+                       getenv("MYSQL_PORT") ? atoi(getenv("MYSQL_PORT"))
+                                            : DRIZZLE_DEFAULT_TCP_PORT,
+                       getenv("MYSQL_USER"),
                        getenv("MYSQL_PASSWORD"),
                        getenv("MYSQL_SCHEMA"), 0);
 

--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Script to print error message with the build is and environment variable
-# DIST_PACKAGE_TARGET
+# MAKE_TARGET
 #
 # $1 error message to show
 #
@@ -15,27 +15,30 @@ print_error_msg ()
 {
     test ! -z "$1" || exit 1
     echo "$1"
-    echo "  os:      $TRAVIS_OS_NAME"
-    echo "  package: $DIST_PACKAGE_TARGET"
+    echo "  os:         $TRAVIS_OS_NAME"
+    echo "  lsb:        $DIST_NAME $DIST_VERSION"
+    echo "  targets:    $MAKE_TARGET"
 
     return 0
 }
 
 # Script which is run before the installation script is called
 #
-# Installs dependencies
-# linux:
-#   deb:
-#     - fpm
-# osx:
+# For linux based builds docker-compose is used to set up the build environment
+#
+# For osx based builds homebrew is used to install required packages:
 #   - sed, (libtool), openssl, mysql
 # Returns 0
 before_install()
 {
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        if [[ "$DIST_PACKAGE_TARGET" == "DEB" ]]; then
-            gem install fpm -v 1.8.1
+        # build images
+        docker-compose -f ./docker-compose.yml \
+            -f ./docker/docker-compose.$DIST_NAME.$DIST_VERSION.yml \
+            build
 
+        # jfrog dependency
+        if [[ "$MAKE_TARGET" =~ "deb" ]]; then
             if [[ -n "$TRAVIS_TAG" && $TRAVIS_REPO_SLUG == "sociomantic-tsunami/libdrizzle-redux" ]]; then
                 curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
                 chmod a+x /tmp/jfrog ;
@@ -81,22 +84,7 @@ enable_mysqlbinlog()
 before_script()
 {
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        if [[ "$DIST_PACKAGE_TARGET" == "DEB" ]]; then
-            # Ensures MySQL is started with binlog enabled. This is done by
-            # modifying the default my.cnf file.
-            #  1. Enable replication in mysql config file
-            #  2. Restart MySQL server
-            #  3. Set root password to an empty string
-            enable_mysqlbinlog "/etc/mysql/my.cnf"
-            sudo service mysql restart
-            mysql -u root -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('')"
-        elif [[ "$DIST_PACKAGE_TARGET" == "RPM" ]]; then
-            # build a docker image with Centos 7 and MySQL
-            docker build -t centos7_mysql56 -f docker/Dockerfile.centos.7 .
-        else
-            print_error_msg "Invalid build configuration"
-            return 1
-        fi
+        echo "Before script not run for docker builds"
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         # Creates a MySQL config file with binary logging enabled and
         # starts the MySQL server
@@ -113,28 +101,23 @@ before_script()
 
 # Invoked by the travis hook script.
 #
-# - configures and compiles the project
-# - runs all unittests with 'make check'
-# - for builds on linux, a deb or rpm package is generated depending on the
-#   current build configuration.
+# Runs ci tests on travis' native build environment or in docker containers
+#
+# Linux:
+#   docker-compose is used to create a container with MySQL and a
+#   container which configures, compiles, tests and possibly builds
+#   distribution packages depending on the build configuration
+#
+# OSX:
+#   Compiles and runs unittests in the travis osx build environment
 #
 # Returns 0 or 1 if called with an invalid build configuration
 run_tests()
 {
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        if [[ "$DIST_PACKAGE_TARGET" == "DEB" ]]; then
-            autoreconf -fi
-            ./configure
-            make check
-            make deb
-        elif [[ "$DIST_PACKAGE_TARGET" == "RPM" ]]; then
-            docker run -d --name db_container centos7_mysql56
-            docker exec -u root db_container sh -c \
-                "autoreconf -fi && ./configure && make rpm"
-        else
-            print_error_msg "Invalid build configuration"
-            return 1
-        fi
+        docker-compose up --abort-on-container-exit
+        # follow the log output in the container building libdrizzle-redux
+        docker logs libdrizzle-redux-container -f
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         autoreconf -fi
         # Pass the root of the openssl installation directory

--- a/yatl/lite.h
+++ b/yatl/lite.h
@@ -59,7 +59,9 @@
 #endif
 
 #ifndef EXIT_SKIP
- #define EXIT_SKIP SKIP_TEST_ON_ERROR ? 77 : EXIT_FAILURE
+ #define EXIT_SKIP (!getenv("DRIZZLE_TEST_EXIT_ERROR_ON_SKIP") ? \
+                    EXIT_FAILURE : atoi(getenv("DRIZZLE_TEST_EXIT_ERROR_ON_SKIP")) ? \
+                    EXIT_FAILURE : 77)
 #endif
 
 static inline bool valgrind_is_caller(void)


### PR DESCRIPTION
The PR changes the existing Travis CI configuration and 
scripts to use docker-compose for all linux based builds.

The main reason is the ability to build and deploy packages 
for Ubuntu Xenial, which is not possible in the native 
travis build environment. 


 