### PR TITLE
Fix brew runtime error on travis

### DIFF
--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -43,6 +43,7 @@ before_install()
             fi
         fi
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew update
         brew install gnu-sed
         xcode_version=`xcodebuild -version | grep 'Xcode' | cut -f 2 -d ' '`
         # reinstall libtool on osx_image xcode6.x to ensure gsed is found by


### PR DESCRIPTION
Homebrew requires Ruby 2.3 to run. The Travis images for OSX are outdated, and the only way to get Homebrew working is to run brew update before doing anything else, as suggested in https://github.com/Homebrew/brew/issues/3299