### PR TITLE
Pass dist version to bintray upload script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ script:
 ## deb package built on ubuntu xenial with gcc
 deploy:
     provider: script
-    script: beaver bintray upload -N pkg/deb/*.deb
+    script: beaver bintray upload -D $DIST_VERSION -N pkg/deb/*.deb
     skip_cleanup: true
     on:
         tags: true # must be a git tag


### PR DESCRIPTION
Fixes an issue where `xenial` deb packages were uploaded to the `trusty` repo on `bintray` because
`lsb_release -cs` was used to get the name of
the **debian** distribution