### PR TITLE
Various fixes to documentation 

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -48,43 +48,43 @@ Functions
 
    Gets the current connection timeout set in the connection object
 
-   :param drizzle: A connection object
+   :param con: A connection object
    :returns: The current timeout
 
 .. c:function:: void drizzle_set_timeout(drizzle_st *con, int timeout)
 
    Sets the connection timeout for the connection object
 
-   :param drizzle: A connection object
+   :param con: A connection object
    :param timeout: The new timeout to set
 
 .. c:function:: drizzle_verbose_t drizzle_verbose(const drizzle_st *con)
 
    Gets the verbosity level set in the connection object
 
-   :param drizzle: A connection object
+   :param con: A connection object
    :returns: The verbosity level from :c:type:`drizzle_verbose_t`
 
 .. c:function:: void drizzle_set_verbose(drizzle_st *con, drizzle_verbose_t verbose)
 
    Sets the verbosity level for the connection object
 
-   :param drizzle: A connection object
+   :param con: A connection object
    :param verbose: The verbosity level from :c:type:`drizzle_verbose_t`
 
 .. c:function:: void drizzle_set_log_fn(drizzle_st *con, drizzle_log_fn *function, void *context)
 
    Sets a callback function for log handling
 
-   :param drizzle: A connection object
+   :param con: A connection object
    :param function: The function to use in the format of :c:func:`drizzle_log_fn`
    :param context: A pointer to data to pass to the log function
 
-.. c:function:: void drizzle_set_event_watch_fn(drizzle_st *drizzle, drizzle_event_watch_fn *function, void *context)
+.. c:function:: void drizzle_set_event_watch_fn(drizzle_st *con, drizzle_event_watch_fn *function, void *context)
 
    Set a custom I/O event watcher function for a drizzle structure
 
-   :param drizzle: Drizzle structure previously initialized with :c:func:`drizzle_create`.
+   :param con: Drizzle structure previously initialized with :c:func:`drizzle_create`.
    :param function: Function to call when there is an I/O event, in the form of :c:func:`drizzle_event_watch_fn`
    :param context: Argument to pass into the callback function.
 
@@ -232,7 +232,7 @@ Functions
    :param options: The options object to modify
    :param state: Set to true/false
 
-.. c:function:: bool drizzle_options_get_interactive(drizzle_options_st *option)
+.. c:function:: bool drizzle_options_get_interactive(drizzle_options_st *options)
 
    Gets the interactive connect option
 
@@ -404,14 +404,14 @@ Functions
 
    Wait for I/O on connections.
 
-   :param drizzle: Drizzle structure previously initialized with :c:func:`drizzle_create`.
+   :param con: Drizzle structure previously initialized with :c:func:`drizzle_create`.
    :returns: Standard drizzle return value.
 
 .. c:function:: drizzle_st *drizzle_ready(drizzle_st *con)
 
    Get next connection that is ready for I/O.
 
-   :param drizzle: Drizzle structure previously initialized with :c:func:`drizzle_create`.
+   :param con: Drizzle structure previously initialized with :c:func:`drizzle_create`.
    :returns: Connection that is ready for I/O, or NULL if there are none.
 
 .. c:function:: drizzle_return_t drizzle_close(drizzle_st *con)

--- a/docs/api/query.rst
+++ b/docs/api/query.rst
@@ -321,6 +321,7 @@ Functions
    Gets the previous column in a buffered column result set
 
    :param result: A result object
+   :param column: The column number
    :returns: A column object
 
 .. c:function:: void drizzle_column_seek(drizzle_result_st *result, uint16_t column)

--- a/docs/api/statement.rst
+++ b/docs/api/statement.rst
@@ -117,6 +117,7 @@ Functions
    :param minutes: The number of minutes for the time
    :param seconds: The number of seconds for the time
    :param microseconds: The number of microseconds for the time
+   :param is_negative: Flag for the sign of the time value
    :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
 
 .. c:function:: drizzle_return_t drizzle_stmt_set_timestamp(drizzle_stmt_st *stmt, uint16_t param_num, uint16_t year, uint8_t month, uint8_t day, uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t microseconds)

--- a/libdrizzle-5.1/column_client.h
+++ b/libdrizzle-5.1/column_client.h
@@ -118,7 +118,7 @@ drizzle_column_st *drizzle_column_prev(drizzle_result_st *result);
  * Seeks to a given column in a buffered column result set
  *
  * @param[in,out] result pointer to the structure to read from.
- * @param[in]     The column number
+ * @param[in]     column The column number
  */
 DRIZZLE_API
 void drizzle_column_seek(drizzle_result_st *result, uint16_t column);

--- a/libdrizzle-5.1/conn.h
+++ b/libdrizzle-5.1/conn.h
@@ -216,7 +216,7 @@ void drizzle_options_set_raw_scramble(drizzle_options_st *options, bool state);
 /**
  * Gets the raw scramble connect option
  *
- * @param[in] options – The options object to get the value from
+ * @param[in] options The options object to get the value from
  * @return The state of the raw scramble option
  */
 DRIZZLE_API
@@ -256,7 +256,7 @@ void drizzle_options_set_interactive(drizzle_options_st *options, bool state);
  * @return The state of the interactive option
  */
 DRIZZLE_API
-bool drizzle_options_get_interactive(drizzle_options_st *option);
+bool drizzle_options_get_interactive(drizzle_options_st *options);
 
 /**
  * Sets/unsets the multi-statements connect option

--- a/libdrizzle-5.1/conn_client.h
+++ b/libdrizzle-5.1/conn_client.h
@@ -94,7 +94,7 @@ drizzle_result_st *drizzle_shutdown(drizzle_st *con, drizzle_return_t *ret_ptr);
 /**
  * Sends a query kill command to the server
  *
- * @param[out] con – A connection object
+ * @param[out] con A connection object
  * @param[in] connection_id – The connection ID to kill a query from
  * @param[out] ret_ptr A pointer to a drizzle_return_t to store the return status into
  * @return A newly allocated result object

--- a/libdrizzle-5.1/conn_client.h
+++ b/libdrizzle-5.1/conn_client.h
@@ -96,7 +96,7 @@ drizzle_result_st *drizzle_shutdown(drizzle_st *con, drizzle_return_t *ret_ptr);
  *
  * @param[out] con – A connection object
  * @param[in] connection_id – The connection ID to kill a query from
- * @param[out] A pointer to a drizzle_return_t to store the return status into
+ * @param[out] ret_ptr A pointer to a drizzle_return_t to store the return status into
  * @return A newly allocated result object
 */
 DRIZZLE_API

--- a/libdrizzle-5.1/drizzle.h
+++ b/libdrizzle-5.1/drizzle.h
@@ -174,12 +174,12 @@ void drizzle_set_log_fn(drizzle_st *con, drizzle_log_fn *function,
  * interested. To resume processing, the libdrizzle function that returned
  * DRIZZLE_RETURN_IO_WAIT should be called again. See drizzle_event_watch_fn().
  *
- * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
+ * @param[in] con Drizzle structure previously initialized with drizzle_create().
  * @param[in] function Function to call when there is an I/O event.
  * @param[in] context Argument to pass into the callback function.
  */
 DRIZZLE_API
-void drizzle_set_event_watch_fn(drizzle_st *drizzle,
+void drizzle_set_event_watch_fn(drizzle_st *con,
                                 drizzle_event_watch_fn *function,
                                 void *context);
 

--- a/libdrizzle-5.1/drizzle.h
+++ b/libdrizzle-5.1/drizzle.h
@@ -111,7 +111,7 @@ const char *drizzle_verbose_name(drizzle_verbose_t verbose);
 /**
  * Get current socket I/O activity timeout value.
  *
- * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
+ * @param[in] con Drizzle structure previously initialized with drizzle_create().
  * @return Timeout in milliseconds to wait for I/O activity. A negative value
  *  means an infinite timeout.
  */
@@ -121,7 +121,7 @@ int drizzle_timeout(const drizzle_st *con);
 /**
  * Set socket I/O activity timeout for connections in a Drizzle structure.
  *
- * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
+ * @param[in] con Drizzle structure previously initialized with drizzle_create().
  * @param[in] timeout Milliseconds to wait for I/O activity. A negative value
  *  means an infinite timeout.
  */
@@ -131,7 +131,7 @@ void drizzle_set_timeout(drizzle_st *con, int timeout);
 /**
  * Get current verbosity threshold for logging messages.
  *
- * @param[in] drizzle Drizzle structure previously initialized with
+ * @param[in] con Drizzle structure previously initialized with
  *  drizzle_create().
  * @return Current verbosity threshold.
  */
@@ -143,7 +143,7 @@ drizzle_verbose_t drizzle_verbose(const drizzle_st *con);
  * DRIZZLE_VERBOSE_NEVER and the drizzle_set_log_fn() callback is set to NULL,
  * messages are printed to STDOUT.
  *
- * @param[in] drizzle Drizzle structure previously initialized with
+ * @param[in] con Drizzle structure previously initialized with
  *  drizzle_create().
  * @param[in] verbose Verbosity threshold of what to log.
  */
@@ -155,7 +155,7 @@ void drizzle_set_verbose(drizzle_st *con, drizzle_verbose_t verbose);
  * for log messages that are above the verbosity threshold set with
  * drizzle_set_verbose().
  *
- * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
+ * @param[in] con Drizzle structure previously initialized with drizzle_create().
  * @param[in] function Function to call when there is a logging message.
  * @param[in] context Argument to pass into the callback function.
  */
@@ -187,7 +187,7 @@ void drizzle_set_event_watch_fn(drizzle_st *drizzle,
 /**
  * Wait for I/O on connections.
  *
- * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
+ * @param[in] con Drizzle structure previously initialized with drizzle_create().
  * @return Standard drizzle return value.
  */
 DRIZZLE_API
@@ -196,7 +196,7 @@ drizzle_return_t drizzle_wait(drizzle_st *con);
 /**
  * Get next connection that is ready for I/O.
  *
- * @param[in] drizzle Drizzle structure previously initialized with drizzle_create().
+ * @param[in] con Drizzle structure previously initialized with drizzle_create().
  * @return Connection that is ready for I/O, or NULL if there are none.
  */
 DRIZZLE_API

--- a/libdrizzle-5.1/query.h
+++ b/libdrizzle-5.1/query.h
@@ -61,8 +61,6 @@ extern "C" {
  * results.
  *
  * @param[in] con connection to use to send the query.
- * @param[in,out] result pointer to an unused structure that will be used for
- *                       the results, or NULL to allocate a new structure.
  * @param[in] query query string to send.
  * @param[in] size length of the query string in bytes.
  * @param[out] ret_ptr pointer to the result code.
@@ -95,9 +93,12 @@ ssize_t drizzle_escape_string(drizzle_st *con, char **to, const char *from, cons
  * Escape a string for an SQL query, optionally for pattern matching.
  *
  * This function escapes the following characters:
- * '\0' (0x00), '\'' (0x27), '"' (0x22), '\b' (0x08), '\n' (0x0A),
- * '\r' (0x0D), '\t' (0x09), '\Z' (0x26), '\\' (0x5C).
- * In case `is_pattern` is set to `true`, '%' (0x25) and '_' (0x5F)
+ *
+ * \verbatim
+'\0' (0x00), '\'' (0x27), '"' (0x22), '\b' (0x08), '\n' (0x0A),
+'\r' (0x0D), '\t' (0x09), '\Z' (0x26), '\\' (0x5C).
+\endverbatim
+ * In case \p is_pattern is set to `true`, '%' (0x25) and '_' (0x5F)
  * will be escaped as well.
  *
  * The to parameter is allocated by the function and needs to be freed by

--- a/libdrizzle-5.1/result.h
+++ b/libdrizzle-5.1/result.h
@@ -58,7 +58,7 @@ extern "C" {
 /**
  * Frees all result objects for a given connection object
  *
- * @param[in,out] con a connection object
+ * @param[in,out] result a connection object
  */
 DRIZZLE_API
 void drizzle_result_free(drizzle_result_st *result);

--- a/libdrizzle-5.1/row_client.h
+++ b/libdrizzle-5.1/row_client.h
@@ -75,7 +75,7 @@ uint64_t drizzle_row_read(drizzle_result_st *result, drizzle_return_t *ret_ptr);
  * drizzle_row_free().
  *
  * @param[in,out] result pointer to the result structure to read from.
- * @param[out] ret_pointer Standard drizzle return value.
+ * @param[out] ret_ptr Standard drizzle return value.
  * @return the row that was read, or NULL if there are no more rows.
  */
 DRIZZLE_API

--- a/libdrizzle-5.1/statement.h
+++ b/libdrizzle-5.1/statement.h
@@ -271,6 +271,7 @@ drizzle_return_t drizzle_stmt_set_null(drizzle_stmt_st *stmt, uint16_t param_num
  * @param minutes The number of minutes for the time
  * @param seconds The number of seconds for the time
  * @param microseconds The number of microseconds for the time
+ * @param is_negative The sign of the time value
  * @return A return status code, DRIZZLE_RETURN_OK upon success
  */
 DRIZZLE_API

--- a/libdrizzle/drizzle_local.h
+++ b/libdrizzle/drizzle_local.h
@@ -71,11 +71,11 @@ void drizzle_free(drizzle_st *con);
 
 /* Create a copy of drizzle_st instance
  *
- * @params[out] drizzle the target instance
+ * @params[out] con the target instance
  * @params[in] from the instance to clone
  * @return a newly allocated and configured copy of a drizzle connection
  */
-drizzle_st *drizzle_clone(drizzle_st *drizzle, const drizzle_st *from);
+drizzle_st *drizzle_clone(drizzle_st *con, const drizzle_st *from);
 
 /*
  * Initialize the shared ssl object, by calling pthread_once

--- a/libdrizzle/drizzle_local.h
+++ b/libdrizzle/drizzle_local.h
@@ -55,7 +55,7 @@ extern "C" {
 /**
  * Set the error string.
  *
- * @param[in] drizzle Drizzle con structure
+ * @param[in] con Drizzle con structure
  * @param[in] function Name of function the error happened in.
  * @param[in] format Format and variable argument list of message.
  */
@@ -120,7 +120,7 @@ bool drizzle_mysql_password_hash(char *to, const char *from, const size_t from_s
 /**
  * Log a message.
  *
- * @param[in] drizzle Drizzle con structure
+ * @param[in] con Drizzle con structure
  * @param[in] verbose Logging level of the message.
  * @param[in] format Format and variable argument list of message.
  * @param[in] args Variable argument list that has been initialized.

--- a/tests/unit/connect.c
+++ b/tests/unit/connect.c
@@ -58,7 +58,6 @@ drizzle_return_t driz_ret;
  * @param[in]  password        password
  * @param[in]  db              database
  * @param[in]  ret_expected    expected return value
- * @param[in]  error_expected  expected error string
  * @param[in]  timeout         connection timeout
  */
 void test_connection_error(const char *host, in_port_t port,


### PR DESCRIPTION
- fix doxygen build warnings 
- fix rst documentation 
- Use name `con` consistently for drizzle_st* 
  func param