### PR TITLE
[TRAVIS] Update apt repo installation for ubuntu docker image

### DIFF
--- a/docker/ubuntu_xenial_image_run.sh
+++ b/docker/ubuntu_xenial_image_run.sh
@@ -6,15 +6,15 @@ echo "# delete all the apt list files to speed up 'apt-get update' command"
 rm -rf /var/lib/apt/lists/*
 
 echo "# install apt repo for clang compiler"
-# install apt repo for clang compiler
+# add apt repo for clang compiler
+wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/apt/sources.list
 echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/apt/sources.list
-gpg --keyserver keyserver.ubuntu.com --recv AF4F7421
 
-echo "deb http://ppa.launchpad.net/saiarcot895/myppa/ubuntu xenial main" >> /etc/apt/sources.list
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DC058F40
+# add apt repo for apt-fast
+add-apt-repository ppa:apt-fast/stable
+
 apt-get update
-
 apt-get install --no-install-recommends -y apt-fast
 # install required packages
 apt-fast -y install --no-install-recommends \


### PR DESCRIPTION
Fixes issue where the explicit fingerprint for llvm
wasn't available on the ubuntu keyserver

Use the ppa:apt-fast repo on launchpad instead of the
ppa:saiarcot895/myppa for apt-fast