### PR TITLE
Change log level verbosity in unittest

### DIFF
--- a/tests/unit/connect.c
+++ b/tests/unit/connect.c
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
     opt_val);
   int cxt = 1;
   drizzle_set_log_fn(con, log_fn_callback, (void*)&cxt);
-  drizzle_set_verbose(con, DRIZZLE_VERBOSE_DEBUG);
+  drizzle_set_verbose(con, DRIZZLE_VERBOSE_INFO);
 
   driz_ret= drizzle_connect(con);
   if (driz_ret == DRIZZLE_RETURN_COULD_NOT_CONNECT)


### PR DESCRIPTION
Change log level in connect unittest to
DRIZZLE_VERBOSE_INFO to sanitize the
output written to stdout