### PR TITLE
[TRAVIS] Minor changes to container_entrypoint.sh

### DIFF
--- a/docker/container_entrypoint.sh
+++ b/docker/container_entrypoint.sh
@@ -25,14 +25,12 @@ install_dependencies()
 install_dependencies
 
 # configure and compile the project
-# run make targets specified in env MAKE_TARGET
-if [[ ! -d ./build ]]; then
-    mkdir build
-fi
+# run make targets specified in the environment variable MAKE_TARGET
+mkdir -p build
 
 cd build
 
-if [[ ! -e ../configure ]]; then
+if [[ ! -e Makefile ]]; then
     autoreconf -fi ..
     ../configure
 fi


### PR DESCRIPTION
Use `mkdir -p build` instead of checking for
existince of directory `build`

Check for existence  `Makefile` instead `configure`
file as condition for running `autoreconf`