### PR TITLE
[TRAVIS] Use 'build stages' on travis and restructure build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: cpp
 
 ## Enable cache for dependencies and directories
-cache: ccache
+cache:
+  directories:
+    - $CACHE_DIR
 
 ## Enable sudo (set explicitly although environment's with docker is sudo
 #  enabled by default
@@ -31,6 +33,7 @@ env:
     - MYSQL_USER=root
     - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
     - SKIP_TEST_ON_ERROR=0
+    - CACHE_DIR=build/travis-cache
 
 ## Build steps for all jobs
 ## Install dependencies
@@ -91,6 +94,8 @@ jobs:
     - <<: *linux-build
       env:
         COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb
+      before_cache:
+        - if [[ -n "$TRAVIS_TAG" ]]; then cp pkg/deb/*.deb $CACHE_DIR/; fi
     - <<: *linux-build
       env:
         CXX=clang++ CC=clang COMPILER_VERSION=3.9
@@ -103,10 +108,12 @@ jobs:
 
     ## Deployment stage
     - <<: *deploy
-      # Deploy deb packages to bintray.
+      # Deploy deb packages to bintray. Doesn't build the packages but uses the
+      # cache from the first stage.
       stage: deploy
       if: tag IS present AND tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+
       env:
         COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb
-      after_success:
-        - beaver bintray upload -D $DIST_VERSION -N pkg/deb/*.deb
+      before_script: skip
+      script:
+        - beaver bintray upload -D $DIST_VERSION -N $CACHE_DIR/*.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,12 @@ os:
 ## Ensures the virtualization environment runs as Ubuntu 14.04 Trusty
 dist: trusty
 
-## Services started on the build environment
-services:
- - docker
-
 ## Environment variables
 #
-#  The 'global' section defines variables which are added to every row in the
-#  build matrix, i.e. every build configuration.
-#  In turn, variables defined in the 'matrix' section each triggers a separate
-#  build.
+#  The 'global' section defines variables common for all jobs
 env:
   global:
     - COMPILER_VERSION=
-    - DEPLOY_PACKAGE=false
     - DIST_NAME=ubuntu
     - DIST_VERSION=xenial
     - DOCKER_COMPOSE_VERSION=1.16.1
@@ -39,40 +31,8 @@ env:
     - MYSQL_USER=root
     - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
     - SKIP_TEST_ON_ERROR=0
-  matrix:
-    - COMPILER_VERSION=4.9 MAKE_TARGET="$MAKE_TARGET:deb" DEPLOY_PACKAGE=true
-    - CXX=clang++ CC=clang COMPILER_VERSION=3.9
-    - DIST_NAME=centos DIST_VERSION=7 MAKE_TARGET=rpm
 
-## Build matrix
-#
-#  Travis expands the environment variables into 6¹ jobs:
-#  All linux based builds are run in docker containers using docker-compose
-#
-#  | os     | compiler    | make targets        |
-#  |--------|-------------|---------------------|
-#  | linux  | clang       | check               |
-#  | linux  | gcc         | check deb           |
-#  | linux  | gcc         | rpm                 |
-#  | osx    | clang 6.1.0 |                     |
-#  | osx    | clang 7.3.0 |                     |
-#  | osx    | clang 8.1.0 |                     |
-#
-#  For osx, the compiler reported is the Apple LLVM version
-#
-#  ¹ Due to excessive build times for osx only XCode 7.3.1 has been enabled.
-matrix:
-  fast_finish: true
-  include:
-    # - os: osx
-    #   osx_image: xcode6.4
-    #   compiler: clang
-    - os: osx
-      compiler: clang
-    # - os: osx
-    #   osx_image: xcode8.3
-    #   compiler: clang
-
+## Build steps for all jobs
 ## Install dependencies
 before_install:
   - ./travis_configure.sh before_install
@@ -85,14 +45,67 @@ before_script:
 script:
   - ./travis_configure.sh run_tests
 
-## Deploy debian packages to bintray
-##
-## deb package built on ubuntu xenial with gcc
-deploy:
-    provider: script
-    script: beaver bintray upload -D $DIST_VERSION -N pkg/deb/*.deb
-    skip_cleanup: true
-    on:
-        tags: true # must be a git tag
-        repo: sociomantic-tsunami/libdrizzle-redux # must be upstream
-        condition: $TRAVIS_OS_NAME = 'linux' && $DIST_NAME = 'ubuntu' && $DIST_VERSION = 'xenial' && $CC = 'gcc' && $MAKE_TARGET =~ 'deb' && $DEPLOY_PACKAGE = 'true'
+## Defines the order of the build stages.
+#
+#  The deployment stage is only done is building semver git tag
+stages:
+  - test
+  - deploy
+
+## Defines the jobs to run in each stage
+#
+#  Travis combines the variables defined in env.global with the variables
+#  defined for each job
+#
+#  The resulting build matrix is as follows:
+#
+#  | os     | dist   | compiler  | make targets | deploy |
+#  |--------|--------|-----------|--------------|--------|
+#  | linux  | ubuntu | clang     | check        | no     |
+#  | linux  | ubuntu | gcc       | check deb    | yes    |
+#  | linux  | centos | gcc       | check rpm    | yes    |
+#  | osx    | sierra | clang¹    | check        | no     |
+#
+#  Linux based builds are run in docker containers using docker-compose.
+#
+#  OSX based builds are done by a third-party provider
+#
+#  ¹ The compiler reported is the Apple LLVM version
+jobs:
+  templates:
+    # Global config for builds on linux
+    - &linux-build
+      services:
+        - docker
+    # Global config for builds on osx
+    - &osx-build
+      os: osx
+      compiler: clang
+    # Global config for deployment stage
+    - &deploy
+      os: linux
+
+  include:
+    # Sets up the build environment, compiles the code and runs tests
+    - <<: *linux-build
+      env:
+        COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb
+    - <<: *linux-build
+      env:
+        CXX=clang++ CC=clang COMPILER_VERSION=3.9
+    - <<: *linux-build
+      env:
+        DIST_NAME=centos DIST_VERSION=7 MAKE_TARGET=rpm
+    - <<: *osx-build
+      env:
+        DIST_NAME=osx
+
+    ## Deployment stage
+    - <<: *deploy
+      # Deploy deb packages to bintray.
+      stage: deploy
+      if: tag IS present AND repo = sociomantic-tsunami/libdrizzle-redux
+      env:
+        COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb
+      after_success:
+        - beaver bintray upload -D $DIST_VERSION -N pkg/deb/*.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ jobs:
     - <<: *deploy
       # Deploy deb packages to bintray.
       stage: deploy
-      if: tag IS present AND repo = sociomantic-tsunami/libdrizzle-redux
+      if: tag IS present AND tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+
       env:
         COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ jobs:
     - &osx-build
       os: osx
       compiler: clang
+      if: tag =~ osx$ OR branch =~ osx$
     # Global config for deployment stage
     - &deploy
       os: linux

--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -34,12 +34,10 @@ before_install()
 {
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         # jfrog dependency
-        if [[ -n "$TRAVIS_TAG" ]]; then
-            if [[ ! -d $HOME/bin || ! -e $HOME/bin/jfrog ]]; then
-                mkdir -p $HOME/bin ;
-                curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > $HOME/bin/jfrog ;
-                chmod a+x $HOME/bin/jfrog ;
-            fi
+        if [[ -n "$TRAVIS_TAG" && ! -e $HOME/bin/jfrog ]]; then
+            mkdir -p $HOME/bin ;
+            curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > $HOME/bin/jfrog ;
+            chmod a+x $HOME/bin/jfrog ;
         fi
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update

--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -35,9 +35,11 @@ before_install()
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         # jfrog dependency
         if [[ -n "$TRAVIS_TAG" ]]; then
-            curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
-            chmod a+x /tmp/jfrog ;
-            sudo cp /tmp/jfrog /usr/local/bin/jfrog ;
+            if [[ ! -d $HOME/bin || ! -e $HOME/bin/jfrog ]]; then
+                mkdir -p $HOME/bin ;
+                curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > $HOME/bin/jfrog ;
+                chmod a+x $HOME/bin/jfrog ;
+            fi
         fi
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update

--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -24,7 +24,8 @@ print_error_msg ()
 
 # Script which is run before the installation script is called
 #
-# For linux based builds docker-compose is used to set up the build environment
+# Only dependencies required in the native travis build environment should be
+# installed in this step.
 #
 # For osx based builds homebrew is used to install required packages:
 #   - sed, (libtool), openssl, mysql
@@ -32,11 +33,6 @@ print_error_msg ()
 before_install()
 {
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        # build images
-        docker-compose -f ./docker-compose.yml \
-            -f ./docker/docker-compose.$DIST_NAME.$DIST_VERSION.yml \
-            build
-
         # jfrog dependency
         if [[ -n "$TRAVIS_TAG" ]]; then
             curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
@@ -79,11 +75,19 @@ enable_mysqlbinlog()
 
 # Invoked by the travis hook before_script to prepare the build environment
 #
+# For linux based builds docker-compose is used to set up the build environment
+#
+# No dependencies required in the native travis build environment should be
+# installed in this step. Use before_install instead
+#
 # Returns 0 or 1 if called with an invalid build configuration
 before_script()
 {
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        echo "Before script not run for docker builds"
+       # build images
+        docker-compose -f ./docker-compose.yml \
+            -f ./docker/docker-compose.$DIST_NAME.$DIST_VERSION.yml \
+            build
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         # Creates a MySQL config file with binary logging enabled and
         # starts the MySQL server

--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -38,12 +38,10 @@ before_install()
             build
 
         # jfrog dependency
-        if [[ "$MAKE_TARGET" =~ "deb" ]]; then
-            if [[ -n "$TRAVIS_TAG" && $TRAVIS_REPO_SLUG == "sociomantic-tsunami/libdrizzle-redux" ]]; then
-                curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
-                chmod a+x /tmp/jfrog ;
-                sudo cp /tmp/jfrog /usr/local/bin/jfrog ;
-            fi
+        if [[ -n "$TRAVIS_TAG" ]]; then
+            curl -XGET -L -k 'https://api.bintray.com/content/jfrog/jfrog-cli-go/$latest/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64' > /tmp/jfrog ;
+            chmod a+x /tmp/jfrog ;
+            sudo cp /tmp/jfrog /usr/local/bin/jfrog ;
         fi
     elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update


### PR DESCRIPTION
Migrate the .travis.yml config file to use
build stages.

Sepearates compilation/testing and deployment into
build stages.

Add user-defined cache directory to avoid building
the deb packages in the deployment stage