### PR TITLE
EndOfSupport for v5.x.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,11 +34,8 @@ Maintained Major Branches
    :header: "Major", "Initial release date", "Supported until"
    :widths: 5, 15, 12
 
-   `v5.x.x`_, `v5.2.0`_: 2016-03-31, 2017-10-06
    `v6.x.x`_, `v6.0.0`_: 2017-04-06, TBA - 6 months after next major release
 
-.. _v5.x.x: https://github.com/sociomantic-tsunami/libdrizzle-redux/tree/v5.x.x
-.. _v5.2.0: https://github.com/sociomantic-tsunami/libdrizzle-redux/tree/v5.2.0
 .. _v6.x.x: https://github.com/sociomantic-tsunami/libdrizzle-redux/tree/v6.x.x
 .. _v6.0.0: https://github.com/sociomantic-tsunami/libdrizzle-redux/tree/v6.0.0
 

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -20,7 +20,6 @@ The parameter ``{distribution}`` should be ``xenial`` while ``{components}`` can
 Then run::
 
     sudo apt update
-    sudo apt install libdrizzle-redux (for versions on the v5.x branch)
     sudo apt install libdrizzle-redux6 (for versions on the v6.x branch)
 
 .. _`bintray`: https://bintray.com/sociomantic-tsunami/libdrizzle-redux/libdrizzle-redux


### PR DESCRIPTION
- Removes v5.x.x from the list of maintained
major branches and instructions for setting
up the libdrizzle-redux bintray repo