### PR TITLE
[TRAVIS] Fix compiler env var overwriteby travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ env:
     - COMPILER_VERSION=
     - DIST_NAME=ubuntu
     - DIST_VERSION=xenial
+    - DOCKER_CXX=g++
+    - DOCKER_CC=gcc
     - DOCKER_COMPOSE_VERSION=1.16.1
     - DRIZZLE_TEST_EXIT_ERROR_ON_SKIP=0
     - MAKE_TARGET=check
@@ -98,7 +100,7 @@ jobs:
         - if [[ -n "$TRAVIS_TAG" ]]; then cp build/pkg/deb/*.deb $CACHE_DIR/; fi
     - <<: *linux-build
       env:
-        CXX=clang++ CC=clang COMPILER_VERSION=3.9
+        DOCKER_CXX=clang++ DOCKER_CC=clang COMPILER_VERSION=3.9
     - <<: *linux-build
       env:
         DIST_NAME=centos DIST_VERSION=7 MAKE_TARGET=rpm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       COMPILER_VERSION: $COMPILER_VERSION
       MAKE_TARGET: $MAKE_TARGET
       DIST_NAME: $DIST_NAME
-      CXX: $CXX
-      CC: $CC
+      CXX: $DOCKER_CXX
+      CC: $DOCKER_CC
     build:
       context: ./
     depends_on:

--- a/docker/container_entrypoint.sh
+++ b/docker/container_entrypoint.sh
@@ -2,20 +2,25 @@
 #
 # entrypoint for the container
 
+# set and export the C and C++ compiler environment variables
+export CXX=$CXX${COMPILER_VERSION:+-$COMPILER_VERSION}
+export CC=$CC${COMPILER_VERSION:+-$COMPILER_VERSION}
+
 install_dependencies()
 {
     if [[ "$DIST_NAME" == "ubuntu" ]]; then
         # install compiler
-        COMPILER=$CXX
-        if [[ ! -z $COMPILER_VERSION ]]; then
-            COMPILER="$CXX-$COMPILER_VERSION"
+        COMPILER_PACKAGE=$CXX
+        if [[ "$CC" =~ "clang" ]]; then
+            COMPILER_PACKAGE=$CC
         fi
-        apt-fast install -y --no-install-recommends $COMPILER
+
+        apt-fast install -y --no-install-recommends $COMPILER_PACKAGE
     fi
 
     if [[ "$DIST_NAME" == "centos" ]]; then
         # install compiler
-        if [[ "$CC" == "clang" ]]; then
+        if [[ "$CC" =~ "clang" ]]; then
             yum install -y clang
         fi
     fi


### PR DESCRIPTION
The CC and CXX environment variables for the travis host build environment are set AFTER the environment variables in the .travis.yml build specification. 

Hence the builds configured with clang and clang++ were being built with gcc and g++