### PR TITLE
Remove validation of SSL_CTX_set_options

### DIFF
--- a/src/ssl.cc
+++ b/src/ssl.cc
@@ -47,11 +47,7 @@
 drizzle_return_t drizzle_set_ssl(drizzle_st *con, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher)
 {
   con->ssl_context= SSL_CTX_new(SSLv23_client_method());
-  if (SSL_CTX_set_options((SSL_CTX*)con->ssl_context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3) != 1)
-  {
-    drizzle_set_error(con, __FILE_LINE_FUNC__, "Cannot set the SSL protocol options");
-    return DRIZZLE_RETURN_SSL_ERROR;
-  }
+  SSL_CTX_set_options((SSL_CTX*)con->ssl_context, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
   if (cipher)
   {


### PR DESCRIPTION
The call SSL_CTX_set_options to returns the new
options bitmask after adding options not 1 for
success