### PR TITLE
Add distribution specific container scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       CXX: $DOCKER_CXX
       CC: $DOCKER_CC
     build:
+      dockerfile: ./docker/Dockerfile.$DIST_NAME.$DIST_VERSION
       context: ./
     depends_on:
       - db
@@ -42,6 +43,7 @@ services:
     volumes:
       - "mysql_socket:/tmp/"
       - ./:/home/libdrizzle-redux/
+      - ./docker/entrypoint.$DIST_NAME.sh:/usr/local/bin/entrypoint.$DIST_NAME.sh
       - ./docker/container_entrypoint.sh:/usr/local/bin/container_entrypoint.sh
     working_dir: /home/libdrizzle-redux/
     entrypoint:

--- a/docker/container_entrypoint.sh
+++ b/docker/container_entrypoint.sh
@@ -1,33 +1,14 @@
 #!/bin/bash
 #
-# entrypoint for the container
+# common entrypoint for the container
+
+COMPILER_VERSION=${COMPILER_VERSION:+-$COMPILER_VERSION}
+
+source "entrypoint.$DIST_NAME.sh"
 
 # set and export the C and C++ compiler environment variables
-export CXX=$CXX${COMPILER_VERSION:+-$COMPILER_VERSION}
-export CC=$CC${COMPILER_VERSION:+-$COMPILER_VERSION}
-
-install_dependencies()
-{
-    if [[ "$DIST_NAME" == "ubuntu" ]]; then
-        # install compiler
-        COMPILER_PACKAGE=$CXX
-        if [[ "$CC" =~ "clang" ]]; then
-            COMPILER_PACKAGE=$CC
-        fi
-
-        apt-fast install -y --no-install-recommends $COMPILER_PACKAGE
-    fi
-
-    if [[ "$DIST_NAME" == "centos" ]]; then
-        # install compiler
-        if [[ "$CC" =~ "clang" ]]; then
-            yum install -y clang
-        fi
-    fi
-}
-
-# install dependencies
-install_dependencies
+export CXX=$CXX$COMPILER_VERSION
+export CC=$CC$COMPILER_VERSION
 
 # configure and compile the project
 # run make targets specified in the environment variable MAKE_TARGET
@@ -37,7 +18,9 @@ cd build
 
 if [[ ! -e Makefile ]]; then
     autoreconf -fi ..
-    ../configure
+    ../configure ${CONFIGURE_ARGS}
 fi
 
 make ${MAKE_TARGET//:/ }
+
+ls -la

--- a/docker/entrypoint.centos.sh
+++ b/docker/entrypoint.centos.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# entrypoint for the container running centos
+
+install_yum_repo()
+{
+    if ! type "$CC" &> /dev/null; then
+        if [[ "$CC" =~ "clang" && -n "$COMPILER_VERSION" ]]; then
+        echo "\
+[alonid-llvm-$COMPILER_VERSION.0]
+name=Copr repo for llvm-$COMPILER_VERSION.0 owned by alonid
+baseurl=https://copr-be.cloud.fedoraproject.org/results/alonid/llvm-$COMPILER_VERSION.0/epel-7-\$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/alonid/llvm-$COMPILER_VERSION.0/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+" >> /etc/yum.repos.d/epel.repo
+        fi
+    fi
+}
+
+install_dependencies()
+{
+    # install compiler
+    COMPILER_PACKAGE=$CC${COMPILER_VERSION:+.0}
+
+    # install compiler
+    if [[ "$CC" =~ "clang" ]]; then
+        install_yum_repo
+        yum install -y COMPILER_PACKAGE
+        export PATH=/opt/llvm-$COMPILER_VERSION.0/bin:$PATH
+    fi
+}
+
+# install dependencies
+install_dependencies
+
+

--- a/docker/entrypoint.ubuntu.sh
+++ b/docker/entrypoint.ubuntu.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# entrypoint for container running ubuntu
+
+install_dependencies()
+{
+    COMPILER_PACKAGE=$CXX$COMPILER_VERSION
+
+    if [[ "$CC" =~ "clang" ]]; then
+        COMPILER_PACKAGE=$CC$COMPILER_VERSION
+    fi
+
+    apt-fast install -y --no-install-recommends $COMPILER_PACKAGE
+}
+
+# install dependencies
+install_dependencies


### PR DESCRIPTION
Reduce the complexity of the existing `container_entrypoint.sh` by moving the distribution specific parts into separate scripts.

Which script is copied to the container depends on the
**$DIST_NAME** environment variable

The `centos` specific script also adds `yum` repositories for additional version of the `clang` compiler 