### PR TITLE
Separate API for getting signed and unsigned numeric values

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,3 +26,10 @@ The modified build process is as follows:
 
 New Features
 ============
+
+API functions for retrieving unsigned 32-bit and 64-bit numbers.
+
+- `drizzle_stmt_get_uint`
+- `drizzle_stmt_get_uint_from_name`
+- `drizzle_stmt_get_biguint_from_name`
+- `drizzle_stmt_get_biguint`

--- a/docs/api/statement.rst
+++ b/docs/api/statement.rst
@@ -50,6 +50,15 @@ Functions
    :param is_unsigned: Set to true if the parameter is unsigned
    :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
 
+.. c:function:: drizzle_return_t drizzle_stmt_set_ushort(drizzle_stmt_st *stmt, uint16_t param_num, uint16_t value)
+
+   Sets a parameter of a prepared statement to a short int value
+
+   :param stmt: A prepared statement object
+   :param param_num: The parameter number to set (starting at 0)
+   :param value: The value to set the parameter
+   :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
+
 .. c:function:: drizzle_return_t drizzle_stmt_set_int(drizzle_stmt_st *stmt, uint16_t param_num, uint32_t value, bool is_unsigned)
 
    Sets a parameter of a prepared statement to an int value
@@ -60,6 +69,15 @@ Functions
    :param is_unsigned: Set to true if the parameter is unsigned
    :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
 
+.. c:function:: drizzle_return_t drizzle_stmt_set_uint(drizzle_stmt_st *stmt, uint16_t param_num, uint32_t value)
+
+   Sets a parameter of a prepared statement to an int value
+
+   :param stmt: A prepared statement object
+   :param param_num: The parameter number to set (starting at 0)
+   :param value: The value to set the parameter
+   :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
+
 .. c:function:: drizzle_return_t drizzle_stmt_set_bigint(drizzle_stmt_st *stmt, uint16_t param_num, uint64_t value, bool is_unsigned)
 
    Sets a parameter of a prepared statement to a bigint value
@@ -68,6 +86,15 @@ Functions
    :param param_num: The parameter number to set (starting at 0)
    :param value: The value to set the parameter
    :param is_unsigned: Set to true if the parameter is unsigned
+   :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
+
+.. c:function:: drizzle_return_t drizzle_stmt_set_biguint(drizzle_stmt_st *stmt, uint16_t param_num, uint64_t value)
+
+   Sets a parameter of a prepared statement to a bigint value
+
+   :param stmt: A prepared statement object
+   :param param_num: The parameter number to set (starting at 0)
+   :param value: The value to set the parameter
    :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
 
 .. c:function:: drizzle_return_t drizzle_stmt_set_double(drizzle_stmt_st *stmt, uint16_t param_num, double value)

--- a/include/libdrizzle-redux/statement.h
+++ b/include/libdrizzle-redux/statement.h
@@ -383,6 +383,19 @@ const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_numbe
                                     size_t *len, drizzle_return_t *ret_ptr);
 
 /**
+ * Get the unsigned int value for a column of a fetched row
+ *
+ * @param stmt The prepared statement object
+ * @param column_number The column number to get (starting at 0)
+ * @param ret_ptr A pointer to a drizzle_return_t to store the return status
+ *  into DRIZZLE_RETURN_TRUNCATED if a truncation has occurred
+ * @return The unsigned int value
+ */
+DRIZZLE_API
+uint32_t drizzle_stmt_get_uint(drizzle_stmt_st *stmt, uint16_t column_number,
+                               drizzle_return_t *ret_ptr);
+
+/**
  * Get the int value for a column of a fetched row
  *
  * @param stmt The prepared statement object
@@ -392,8 +405,22 @@ const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_numbe
  * @return The int value
  */
 DRIZZLE_API
-uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number,
-                              drizzle_return_t *ret_ptr);
+int32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number,
+                             drizzle_return_t *ret_ptr);
+
+/**
+ * Get the unsigned int value for a column of a fetched row using a column name
+ *
+ * @param stmt The prepared statement object
+ * @param column_name The column name to get
+ * @param ret_ptr A pointer to a drizzle_return_t to store the return status
+ * into DRIZZLE_RETURN_TRUNCATED if a truncation has occurred,
+ * DRIZZLE_RETURN_NOT_FOUND if the column name cannot be found
+ * @return The unsigned int value
+ */
+DRIZZLE_API
+uint32_t drizzle_stmt_get_uint_from_name(drizzle_stmt_st *stmt, const char *column_name,
+                                         drizzle_return_t *ret_ptr);
 
 /**
  * Get the int value for a column of a fetched row using a column name
@@ -406,8 +433,8 @@ uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number,
  * @return The int value
  */
 DRIZZLE_API
-uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *column_name,
-                                        drizzle_return_t *ret_ptr);
+int32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *column_name,
+                                       drizzle_return_t *ret_ptr);
 
 /**
  * Get the bigint value for a column of a fetched row using a column name
@@ -420,7 +447,21 @@ uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *colum
  * @return The bigint value
  */
 DRIZZLE_API
-uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name,
+int64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name,
+                                           drizzle_return_t *ret_ptr);
+
+/**
+ * Get the unsigned bigint value for a column of a fetched row using a column name
+ *
+ * @param stmt The prepared statement object
+ * @param column_name The column name to get
+ * @param ret_ptr A pointer to a drizzle_return_t to store the return status
+ * into DRIZZLE_RETURN_TRUNCATED if a truncation has occurred,
+ *
+ * @return The unsigned bigint value
+ */
+DRIZZLE_API
+uint64_t drizzle_stmt_get_biguint_from_name(drizzle_stmt_st *stmt, const char *column_name,
                                            drizzle_return_t *ret_ptr);
 
 /**
@@ -433,8 +474,22 @@ uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *co
  * @return The bigint value
  */
 DRIZZLE_API
-uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number,
+int64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number,
                                  drizzle_return_t *ret_ptr);
+
+/**
+ * Get the unsigned bigint value for a column of a fetched row
+ *
+ * @param stmt The prepared statement object
+ * @param column_number The column number to get (starting at 0)
+ * @param ret_ptr A pointer to a drizzle_return_t to store the return status
+ * into DRIZZLE_RETURN_TRUNCATED if a truncation has occurred
+ * @return The unsigned bigint value
+ */
+DRIZZLE_API
+uint64_t drizzle_stmt_get_biguint(drizzle_stmt_st *stmt, uint16_t column_number,
+                                 drizzle_return_t *ret_ptr);
+
 /**
  * Get the double value for a column of a fetched row
  *

--- a/include/libdrizzle-redux/statement.h
+++ b/include/libdrizzle-redux/statement.h
@@ -188,6 +188,19 @@ DRIZZLE_API
 drizzle_return_t drizzle_stmt_set_short(drizzle_stmt_st *stmt, uint16_t param_num,
                                         uint16_t value, bool is_unsigned);
 
+/*
+ * Sets a parameter of a prepared statement to a short int value
+ *
+ * @param stmt A prepared statement object
+ * @param param_num The parameter number to set (starting at 0)
+ * @param value The value to set the parameter
+ * @param is_unsigned Set to true if the parameter is unsigned
+ * @return A return status code, DRIZZLE_RETURN_OK upon success
+ */
+DRIZZLE_API
+drizzle_return_t drizzle_stmt_set_ushort(drizzle_stmt_st *stmt, uint16_t param_num,
+                                        uint16_t value, bool is_unsigned);
+
 /**
  * Sets a parameter of a prepared statement to an int value
  *
@@ -202,6 +215,19 @@ drizzle_return_t drizzle_stmt_set_int(drizzle_stmt_st *stmt, uint16_t param_num,
                                       uint32_t value, bool is_unsigned);
 
 /**
+ * Sets a parameter of a prepared statement to an int value
+ *
+ * @param stmt A prepared statement object
+ * @param param_num The parameter number to set (starting at 0)
+ * @param value The value to set the parameter
+ * @param is_unsigned Set to true if the parameter is unsigned
+ * @return A return status code, DRIZZLE_RETURN_OK upon success
+ */
+DRIZZLE_API
+drizzle_return_t drizzle_stmt_set_uint(drizzle_stmt_st *stmt, uint16_t param_num,
+                                      uint32_t value);
+
+/**
  * Sets a parameter of a prepared statement to a bigint value
  *
  * @param stmt A prepared statement object
@@ -213,6 +239,19 @@ drizzle_return_t drizzle_stmt_set_int(drizzle_stmt_st *stmt, uint16_t param_num,
 DRIZZLE_API
 drizzle_return_t drizzle_stmt_set_bigint(drizzle_stmt_st *stmt, uint16_t param_num,
                                          uint64_t value, bool is_unsigned);
+
+/**
+ * Sets a parameter of a prepared statement to a bigint value
+ *
+ * @param stmt A prepared statement object
+ * @param param_num The parameter number to set (starting at 0)
+ * @param value The value to set the parameter
+ * @param is_unsigned Set to true if the parameter is unsigned
+ * @return A return status code, DRIZZLE_RETURN_OK upon success
+ */
+DRIZZLE_API
+drizzle_return_t drizzle_stmt_set_biguint(drizzle_stmt_st *stmt, uint16_t param_num,
+                                         uint64_t value);
 
 /**
  * Sets a parameter of a prepared statement to a double value

--- a/src/statement_local.h
+++ b/src/statement_local.h
@@ -57,4 +57,10 @@ uint16_t drizzle_stmt_column_lookup(drizzle_result_st *result, const char *colum
 
 #ifdef __cplusplus
 }
+
+template <typename DST_TYPE, typename SRC_SIGNED, typename SRC_UNSIGNED>
+DST_TYPE signedness_cast(const unsigned char *src, bool is_unsigned);
+
+template<typename U>
+U drizzle_get_integer(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
 #endif

--- a/src/statement_param.cc
+++ b/src/statement_param.cc
@@ -92,6 +92,17 @@ drizzle_return_t drizzle_stmt_set_short(drizzle_stmt_st *stmt, uint16_t param_nu
   return drizzle_stmt_set_param(stmt, param_num, DRIZZLE_COLUMN_TYPE_SHORT, val, 2, is_unsigned);
 }
 
+drizzle_return_t drizzle_stmt_set_ushort(drizzle_stmt_st *stmt, uint16_t param_num,
+                                        uint16_t value)
+{
+  uint16_t *val;
+  CHECK_PARAM_NUM;
+  val= (uint16_t*) stmt->query_params[param_num].data_buffer;
+  *val= value;
+
+  return drizzle_stmt_set_param(stmt, param_num, DRIZZLE_COLUMN_TYPE_SHORT, val, 2, true);
+}
+
 drizzle_return_t drizzle_stmt_set_int(drizzle_stmt_st *stmt, uint16_t param_num, uint32_t value, bool is_unsigned)
 {
   uint32_t *val;
@@ -102,6 +113,17 @@ drizzle_return_t drizzle_stmt_set_int(drizzle_stmt_st *stmt, uint16_t param_num,
   return drizzle_stmt_set_param(stmt, param_num, DRIZZLE_COLUMN_TYPE_LONG, val, 4, is_unsigned);
 }
 
+drizzle_return_t drizzle_stmt_set_uint(drizzle_stmt_st *stmt, uint16_t param_num,
+                                      uint32_t value)
+{
+  uint32_t *val;
+  CHECK_PARAM_NUM;
+  val= (uint32_t*) stmt->query_params[param_num].data_buffer;
+  *val= value;
+
+  return drizzle_stmt_set_param(stmt, param_num, DRIZZLE_COLUMN_TYPE_LONG, val, 4, true);
+}
+
 drizzle_return_t drizzle_stmt_set_bigint(drizzle_stmt_st *stmt, uint16_t param_num, uint64_t value, bool is_unsigned)
 {
   uint64_t *val;
@@ -110,6 +132,16 @@ drizzle_return_t drizzle_stmt_set_bigint(drizzle_stmt_st *stmt, uint16_t param_n
   *val= value;
 
   return drizzle_stmt_set_param(stmt, param_num, DRIZZLE_COLUMN_TYPE_LONGLONG, val, 8, is_unsigned);
+}
+
+drizzle_return_t drizzle_stmt_set_biguint(drizzle_stmt_st *stmt, uint16_t param_num, uint64_t value)
+{
+  uint64_t *val;
+  CHECK_PARAM_NUM;
+  val= (uint64_t*) stmt->query_params[param_num].data_buffer;
+  *val= value;
+
+  return drizzle_stmt_set_param(stmt, param_num, DRIZZLE_COLUMN_TYPE_LONGLONG, val, 8, true);
 }
 
 drizzle_return_t drizzle_stmt_set_double(drizzle_stmt_st *stmt, uint16_t param_num, double value)


### PR DESCRIPTION
Refactor statement_param.cc and add a templated function
for retrieval of signed and unsigned integer types.

Add API function for extracting unsigned integer and long types.