### PR TITLE
Fix error handling in drizzle_binlog_get_filename     

### DIFF
--- a/docs/api/binlog.rst
+++ b/docs/api/binlog.rst
@@ -182,4 +182,8 @@ Functions
    :param filename: Buffer to copy filename to
    :param end_position: Variable to save the size of the binlog file into
    :param file_index: Index of the binlog to retrieve.
-   :returns: Standard drizzle return value
+   :returns: Standard drizzle return value:
+
+            - DRIZZLE_RETURN_OK the filename was retrieved successfully.
+            - DRIZZLE_RETURN_INVALID_ARGUMENT: invalid argument(s)
+            - DRIZZLE_RETURN_NOT_FOUND: no binlog files were available

--- a/include/libdrizzle-redux/binlog.h
+++ b/include/libdrizzle-redux/binlog.h
@@ -225,6 +225,9 @@ const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_typ
  * @param[in,out] end_position Variable to save the size of the binlog file into
  * @param[in] file_index Index of the binlog to retrieve.
  * @return Standard drizzle return value
+ *         - DRIZZLE_RETURN_OK the filename was retrieved successfully.
+ *         - DRIZZLE_RETURN_INVALID_ARGUMENT: invalid argument(s)
+ *         - DRIZZLE_RETURN_NOT_FOUND: no binlog files were available
  */
 DRIZZLE_API
 drizzle_return_t drizzle_binlog_get_filename(drizzle_st *con, char **filename,

--- a/src/binlog.cc
+++ b/src/binlog.cc
@@ -534,7 +534,9 @@ drizzle_return_t drizzle_binlog_get_filename(drizzle_st *con, char **filename,
   }
   else
   {
-    drizzle_log_info(con, __FILE_LINE_FUNC__, "No binary log files found");
+    drizzle_set_error(con, __FILE_LINE_FUNC__, "No binary log files found");
+    drizzle_result_free(result);
+    return DRIZZLE_RETURN_NOT_FOUND;
   }
 
   drizzle_result_free(result);


### PR DESCRIPTION
The error was logged with verbosity level **DRIZZLE_VERBOSE_DEBUG**

In addition the function returns **DRIZZLE_RETURN_OK** when no binlog files were available on the server. 
Instead use `drizzle_set_error` and return status **DRIZZLE_RETURN_NOT_FOUND**.

Update docs for `drizzle_binlog_get_filename`