### PR TITLE
Fix wrong verbosity level passed to drizzle_log

### DIFF
--- a/src/drizzle_local.h
+++ b/src/drizzle_local.h
@@ -164,7 +164,7 @@ static inline void drizzle_log_error(drizzle_st *con, const char* file, uint lin
   if (con->verbose >= DRIZZLE_VERBOSE_ERROR)
   {
     va_start(args, format);
-    drizzle_log(con, file, line, func, DRIZZLE_VERBOSE_DEBUG, format, args);
+    drizzle_log(con, file, line, func, DRIZZLE_VERBOSE_ERROR, format, args);
     va_end(args);
   }
 }
@@ -180,7 +180,7 @@ static inline void drizzle_log_info(drizzle_st *con, const char* file, uint line
   if (con->verbose >= DRIZZLE_VERBOSE_INFO)
   {
     va_start(args, format);
-    drizzle_log(con, file, line, func, DRIZZLE_VERBOSE_DEBUG, format, args);
+    drizzle_log(con, file, line, func, DRIZZLE_VERBOSE_INFO, format, args);
     va_end(args);
   }
 }


### PR DESCRIPTION
The patch f0634e049d397c954f03099bdb82316a8ac91605 introduced a bug where the functions `drizzle_log_info` and `drizzle_log_error` both passed **DRIZZLE_VERBOSE_DEBUG** as verbosity to `drizzle_log`