### PR TITLE
[TRAVIS] Fix MySQL installation for OSX build

### DIFF
--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -49,7 +49,8 @@ before_install()
             brew reinstall libtool
         fi
         brew install openssl
-        brew install mysql
+        brew install mysql@5.7
+        brew link --overwrite --force mysql@5.7
     else
         print_error_msg "Invalid build configuration"
         return 1


### PR DESCRIPTION
[TRAVIS] Fix MySQL installation for OSX build

Fixes an issue where OSX on travis failed after the default version installed by brew changed to v8.x

- Install v5.7.x specifically by using the MySQL formula mysql@5.7
- link the MySQL installation with --overwrite and --force to make the mysql executable available as `mysql`