### PR TITLE
Add support for api-sanity-checker tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ jobs:
     # Sets up the build environment, compiles the code and runs tests
     - <<: *linux-build
       env:
-        COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb
+        COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb:api-sanity-checker
       before_cache:
         - if [[ -n "$TRAVIS_TAG" ]]; then cp build/pkg/deb/*.deb $CACHE_DIR/; fi
     - <<: *linux-build

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,7 @@ maintainer-clean-local:
 	rm -f @PACKAGE@-*.tar.gz; \
 	rm -f ./pkg/rpm/@PACKAGE@-*.rpm; \
 	rm -f ./pkg/deb/@PACKAGE@-*.deb; \
-	rm -rf pkg/deb/install
+	rm -rf pkg/deb/install \
+	rm -rf libsample_c* test_results tests/libdrizzle-redux* libsample_*
 
 dist_bin_SCRIPTS+= @GENERIC_CONFIG@

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,7 @@ AC_CONFIG_FILES([Makefile
                  docs/conf.py
                  pkg/rpm/spec
                  include/libdrizzle-redux/version.h:$srcdir/include/libdrizzle-redux/version.h.in
+                 api-sanity-checker-version.xml:$srcdir/tests/api-sanity-checker-version.xml.in
                  ])
 AC_CONFIG_FILES([pkg/deb/build:$srcdir/pkg/deb/build],[chmod +x pkg/deb/build])
 

--- a/docker/Dockerfile.ubuntu.xenial
+++ b/docker/Dockerfile.ubuntu.xenial
@@ -28,4 +28,4 @@ RUN apt-get install --no-install-recommends -y apt-fast
 
 # install required packages
 RUN apt-fast -y install --no-install-recommends \
-    libssl-dev autoconf libtool make automake zlib1g-dev
+    libssl-dev autoconf libtool make automake zlib1g-dev api-sanity-checker

--- a/tests/api-sanity-checker-version.xml.in
+++ b/tests/api-sanity-checker-version.xml.in
@@ -1,0 +1,11 @@
+<version>
+    @VERSION@
+</version>
+
+<headers>
+    @abs_builddir@/install/usr/include/include
+</headers>
+
+<libs>
+    @abs_builddir@/install/usr/lib
+</libs>

--- a/tests/unit/include.am
+++ b/tests/unit/include.am
@@ -160,3 +160,12 @@ gdb-ssl: tests/unit/ssl
 
 check-ssl: tests/unit/ssl
 	tests/unit/ssl
+
+api-sanity-checker:
+	${abs_top_srcdir}/configure --prefix=/usr --srcdir=${abs_top_srcdir}
+	$(MAKE) DESTDIR=${abs_builddir}/install install
+	api-sanity-checker  -l @PACKAGE_NAME@ -d ${abs_builddir}/api-sanity-checker-version.xml -gen -build -run
+
+clean-api-sanity-checker:
+	api-sanity-checker -l @PACKAGE_NAME@ -d ${abs_builddir}/api-sanity-checker-version.xml -clean
+	rm -rf libsample_c* test_results tests/libdrizzle-redux* tests/libsample_*


### PR DESCRIPTION
The api-sanity-checker the tool is an automatic generator of basic unit tests.
The PR adds a make target for running api-sanity-checker against the codebase and adds api-sanity-checker to the ci build

For more info about the tool: https://lvc.github.io/api-sanity-checker/