### PR TITLE
[TRAVIS] Disable conditional osx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,8 @@ jobs:
     - &osx-build
       os: osx
       compiler: clang
-      if: tag =~ osx$ OR branch =~ osx$
+    # Enable the build condition if travis' osx service startup hangs
+    # if: tag =~ osx$ OR branch =~ osx$
     # Global config for deployment stage
     - &deploy
       os: linux


### PR DESCRIPTION
Startup times for OSX builds on travis are now
acceptable. Hence the condition is disabled
in the travis build configuration