### PR TITLE
[TRAVIS] Bugfix: 'overwrite' of make exit code

### DIFF
--- a/docker/container_entrypoint.sh
+++ b/docker/container_entrypoint.sh
@@ -22,5 +22,3 @@ if [[ ! -e Makefile ]]; then
 fi
 
 make ${MAKE_TARGET//:/ }
-
-ls -la


### PR DESCRIPTION
The `ls -la` introduced in cf16ca08c9c70b73e09364328f4bc1820d41ae93 was overwriting the exit code from `make`.
This caused all docker containers exit with `0`, effectively making the ci tests status unusable