### PR TITLE
Add api-sanity-checker-version.xml.in to EXTRA_DIST

### DIFF
--- a/tests/include.am
+++ b/tests/include.am
@@ -2,4 +2,6 @@
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
 
+EXTRA_DIST+=tests/api-sanity-checker-version.xml.in
+
 include tests/unit/include.am


### PR DESCRIPTION
The file `api-sanity-checker-version.xml.in` is required for the `make install` target