### PR TITLE
Replace copyright notices to dunnhumby Germany GmbH

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,6 @@ The primary reason for the fork is that development of the upstream stopped in 2
 which meant that crucial fixes and enhancements were not included in the latest
 stable release **v5.1.4 Felmingham**.
 
-The repository is part of the `Tsunami programme`_ created by `sociomantic labs GmbH`_
-in order to support developers who want to contribute to the open source community.
-
 We hope that continuing the development of **libdrizzle-redux** can benefit current
 and future users of the library.
 
@@ -161,8 +158,7 @@ We appreciate any contributions to the development of **libdrizzle-redux**.
 One requirement is that the changes should be added in accordance with a
 versioning scheme based on SemVer.
 A set of guidelines guidelines and tools to help developers and users are
-available at the wiki of the `Neptune`_ project, which is also part of
-the `Tsunami programme`_ created by `sociomantic labs GmbH`_.
+available at the wiki of the `Neptune`_ project.
 
 .. |travis| image:: https://travis-ci.org/sociomantic-tsunami/libdrizzle-redux.svg?branch=master
    :alt: Travis Build Status
@@ -173,6 +169,4 @@ the `Tsunami programme`_ created by `sociomantic labs GmbH`_.
 .. _All: https://github.com/sociomantic-tsunami/libdrizzle-redux/releases/
 .. _here: https://github.com/sociomantic-tsunami/neptune/blob/v0.x.x/doc/library-user.rst
 .. _compiling.rst: https://github.com/andreas-bok-sociomantic/libdrizzle-redux/blob/v5.4.x/docs/compiling.rst
-.. _Tsunami programme: https://github.com/sociomantic-tsunami
-.. _sociomantic labs GmbH: https://www.sociomantic.com
 .. _Neptune: https://github.com/sociomantic-tsunami/neptune/blob/v0.x.x/doc/library-user.rst#contributing-to-a-neptune-versioned-library

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -49,7 +49,7 @@ master_doc = 'index'
 project = u'libdrizzle redux'
 description = u'Libdrizzle Redux Documentation'
 copyright = u'2008-2013 Drizzle Development Group http://drizzle.org\n\n' + \
-            u'2015-2016 Sociomantic Labs GmbH https://github.com/sociomantic-tsunami/libdrizzle-redux'
+            u'2015-2016 dunnhumby Germany GmbH https://github.com/sociomantic-tsunami/libdrizzle-redux'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/m4/ax_enable_ssl.m4
+++ b/m4/ax_enable_ssl.m4
@@ -10,7 +10,7 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2016 Sociomantic Labs, All rights reserved
+#   Copyright (c) 2016 dunnhumby Germany GmbH, All rights reserved
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice

--- a/pkg/deb/build
+++ b/pkg/deb/build
@@ -60,7 +60,7 @@ pkgversion=$(git describe --dirty | cut -c2- |
 pkgmaint=$(echo "`git config user.name` <`git config user.email`>")
 description="Simple Asynchronous C API to MySQL databases"
 url="https://github.com/sociomantic-tsunami/libdrizzle-redux"
-vendor="Sociomantic Labs GmbH"
+vendor="dunnhumby Germany GmbH"
 license="Simplified BSD License"
 
 # the package name used in the distribution

--- a/tests/unit/event_callback.c
+++ b/tests/unit/event_callback.c
@@ -2,7 +2,7 @@
  *
  * Drizzle Client & Protocol Library
  *
- * Copyright (C) 2016 Sociomantic Labs GmbH
+ * Copyright (c) 2016 dunnhumby Germany GmbH
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/travis_configure.sh
+++ b/travis_configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Script for setting up OS specific CI test environment on travis-ci.org
 #
-# Copyright: Copyright (c) 2017 sociomantic labs GmbH. All rights reserved
+# Copyright: Copyright (c) 2017 dunnhumby Germany GmbH. All rights reserved
 
 set -e
 


### PR DESCRIPTION
Due to organizational changes in sociomantic labs GmbH the copyright owner must be updated to the legal entity "dunnhumby Germany GmbH".