### PR TITLE
Update docker images to sociomantictsunami/develbase

### DIFF
--- a/docker/Dockerfile.ubuntu.xenial
+++ b/docker/Dockerfile.ubuntu.xenial
@@ -1,5 +1,5 @@
 # Dockerfile for building an image with ubuntu xenial
-FROM sociomantictsunami/base
+FROM sociomantictsunami/develbase
 MAINTAINER andreas-bok-sociomantic <andreas.bok@sociomantic.com>
 
 ADD docker/ubuntu_xenial_image_run.sh  /usr/local/bin/


### PR DESCRIPTION
The current `sociomantictsunami/base` image has been moved to `sociomantictsunami/develbase/`