### PR TITLE
Add const to params for non-mutating functions

### DIFF
--- a/docs/api/binlog.rst
+++ b/docs/api/binlog.rst
@@ -33,7 +33,7 @@ There are two callback functions.  The first is called whenever a new event is
 available to retrieve.  The second is triggered whenever an error (or EOF)
 occurs.
 
-.. c:function:: void (drizzle_binlog_fn)(drizzle_binlog_event_st *event, void *context)
+.. c:function:: void (drizzle_binlog_fn)(const drizzle_binlog_event_st *event, void *context)
 
    This defines the function that will be supplied to accept binlog events
 
@@ -90,70 +90,70 @@ Functions
    :param event: The event from the binlog stream
    :returns: The timestamp for the binlog event
 
-.. c:function:: drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *event)
+.. c:function:: drizzle_binlog_event_types_t drizzle_binlog_event_type(const drizzle_binlog_event_st *event)
 
    Get the event type for the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: The timestamp for the binlog event
 
-.. c:function:: uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event)
+.. c:function:: uint32_t drizzle_binlog_event_server_id(const drizzle_binlog_event_st *event)
 
    Get the server_id for the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: The server_id for the binlog event
 
-.. c:function:: uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event)
+.. c:function:: uint32_t drizzle_binlog_event_length(const drizzle_binlog_event_st *event)
 
    Get the length of the event data received by the event callback
 
    :param event: The event from binlog stream
    :returns: The event data length
 
-.. c:function:: uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event)
+.. c:function:: uint32_t drizzle_binlog_event_next_pos(const drizzle_binlog_event_st *event)
 
    Get the next event position from the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: The next event position
 
-.. c:function:: uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event)
+.. c:function:: uint16_t drizzle_binlog_event_flags(const drizzle_binlog_event_st *event)
 
    Get the flags for the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: The event flags
 
-.. c:function:: uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event)
+.. c:function:: uint16_t drizzle_binlog_event_extra_flags(const drizzle_binlog_event_st *event))
 
    Get the extra flags for the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: The extra event flags
 
-.. c:function:: const unsigned char* drizzle_binlog_event_data(drizzle_binlog_event_st *event)
+.. c:function:: const unsigned char* drizzle_binlog_event_data(const drizzle_binlog_event_st *event)
 
    Get the event data for the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: A pointer to the event data
 
-.. c:function:: const unsigned char* drizzle_binlog_event_raw_data(drizzle_binlog_event_st *event)
+.. c:function:: const unsigned char* drizzle_binlog_event_raw_data(const drizzle_binlog_event_st *event)
 
    Get the raw event data (including header) for the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: A pointer to the raw event data
 
-.. c:function:: uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event)
+.. c:function:: uint32_t drizzle_binlog_event_raw_length(const drizzle_binlog_event_st *event)
 
    Get the length of the raw event data (including header) for the event received by the event callback
 
    :param event: The event from the binlog stream
    :returns: The length of the raw event data
 
-.. c:function:: const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type)
+.. c:function:: const char *drizzle_binlog_event_type_str(const drizzle_binlog_event_types_t event_type)
 
    Get the event type for the binlog event as string
 

--- a/docs/api/binlog.rst
+++ b/docs/api/binlog.rst
@@ -83,7 +83,7 @@ Functions
    :param start_position: The position of the binlog file to start at, a value of less than 4 is set to 4 due to the binlog header taking the first 4 bytes
    :returns: A Drizzle return type.  :py:const:`DRIZZLE_RETURN_OK` upon success.
 
-.. c:function:: uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event)
+.. c:function:: uint32_t drizzle_binlog_event_timestamp(const drizzle_binlog_event_st *event)
 
    Get the timestamp for the event received by the event callback
 

--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -174,7 +174,7 @@ Functions
    :param option: the option to set the value for
    :param value: the value to set
 
-.. c:function:: int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option)
+.. c:function:: int drizzle_socket_get_option(const drizzle_st *con, drizzle_socket_option_t option)
 
    Gets the value of a socket option. See :c:func:`drizzle_socket_set_options`
    for a description of the available options
@@ -190,7 +190,7 @@ Functions
    :param options: The options object to modify
    :param state: Set option to true/false
 
-.. c:function:: bool drizzle_options_get_non_blocking(drizzle_options_st *options)
+.. c:function:: bool drizzle_options_get_non_blocking(const drizzle_options_st *options)
 
    Gets the non-blocking connect option
 
@@ -204,7 +204,7 @@ Functions
    :param options: The options object to modify
    :param state: Set to true/false
 
-.. c:function:: bool drizzle_options_get_raw_scramble(drizzle_options_st *options)
+.. c:function:: bool drizzle_options_get_raw_scramble(const drizzle_options_st *options)
 
    Gets the raw scramble connect option
 
@@ -218,7 +218,7 @@ Functions
    :param options: The options object to modify
    :param state: Set to true/false
 
-.. c:function:: bool drizzle_options_get_found_rows(drizzle_options_st *options)
+.. c:function:: bool drizzle_options_get_found_rows(const drizzle_options_st *options)
 
    Gets the found rows connect option
 
@@ -232,7 +232,7 @@ Functions
    :param options: The options object to modify
    :param state: Set to true/false
 
-.. c:function:: bool drizzle_options_get_interactive(drizzle_options_st *options)
+.. c:function:: bool drizzle_options_get_interactive(const drizzle_options_st *options)
 
    Gets the interactive connect option
 
@@ -246,7 +246,7 @@ Functions
    :param options: The options object to modify
    :parma state: Set to true/false
 
-.. c:function:: bool drizzle_options_get_multi_statements(drizzle_options_st *options)
+.. c:function:: bool drizzle_options_get_multi_statements(const drizzle_options_st *options)
 
    Gets the multi-statements connect option
 
@@ -260,7 +260,7 @@ Functions
    :param options: The options object to modify
    :param state: Set to true/false
 
-.. c:function:: bool drizzle_options_get_auth_plugin(drizzle_options_st *options)
+.. c:function:: bool drizzle_options_get_auth_plugin(const drizzle_options_st *options)
 
    Gets the auth plugin connect option
 
@@ -274,7 +274,7 @@ Functions
    :param options: The options object to modify
    :param owner: The owner of the socket connection
 
-.. c:function:: drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options)
+.. c:function:: drizzle_socket_owner_t drizzle_options_get_socket_owner(const drizzle_options_st *options)
 
    Gets the owner of the socket connection
 

--- a/docs/api/library.rst
+++ b/docs/api/library.rst
@@ -30,7 +30,7 @@ Functions
 
    :returns: A string containing the bug report URL
 
-.. c:function:: const char* drizzle_verbose_name(drizzle_verbose_t verbose)
+.. c:function:: const char* drizzle_verbose_name(const drizzle_verbose_t verbose)
 
    Gives the verbosity name for a given verbosity type
 

--- a/docs/api/query.rst
+++ b/docs/api/query.rst
@@ -91,42 +91,42 @@ Functions
    :param result: A result object
    :returns: The connection object associated to the result object
 
-.. c:function:: bool drizzle_result_eof(drizzle_result_st *result)
+.. c:function:: bool drizzle_result_eof(const drizzle_result_st *result)
 
    Tests to see if an EOF packet has been hit
 
    :param result: A result object
    :returns: true on EOF or false
 
-.. c:function:: const char* drizzle_result_message(drizzle_result_st *result)
+.. c:function:: const char* drizzle_result_message(const drizzle_result_st *result)
 
    Get error or information message from result set
 
    :param result: A result object
    :returns: The message to be returned
 
-.. c:function:: uint16_t drizzle_result_error_code(drizzle_result_st *result)
+.. c:function:: uint16_t drizzle_result_error_code(const drizzle_result_st *result)
 
    Gets the error code from a result set
 
    :param result: A result object
    :returns: The error code
 
-.. c:function:: const char* drizzle_result_sqlstate(drizzle_result_st *result)
+.. c:function:: const char* drizzle_result_sqlstate(const drizzle_result_st *result)
 
    Gets the SQL state from a result set
 
    :param result: A result object
    :returns: The SQL state string
 
-.. c:function:: uint16_t drizzle_result_warning_count(drizzle_result_st *result)
+.. c:function:: uint16_t drizzle_result_warning_count(const drizzle_result_st *result)
 
    Gets the warning count from a result set
 
    :param result: A result object
    :retuns: The warning count
 
-.. c:function:: uint64_t drizzle_result_insert_id(drizzle_result_st *result)
+.. c:function:: uint64_t drizzle_result_insert_id(const drizzle_result_st *result)
 
    Gets the insert ID for an auto_increment column in a result set
 
@@ -137,21 +137,21 @@ Functions
    :param result: A result object
    :returns: The insert ID
 
-.. c:function:: uint64_t drizzle_result_affected_rows(drizzle_result_st *result)
+.. c:function:: uint64_t drizzle_result_affected_rows(const drizzle_result_st *result)
 
    Gets the affected row count from a result set
 
    :param result: A result object
    :returns: The affected row count
 
-.. c:function:: uint16_t drizzle_result_column_count(drizzle_result_st *result)
+.. c:function:: uint16_t drizzle_result_column_count(const drizzle_result_st *result)
 
    Gets the column count from a result set
 
    :param result: A result object
    :returns: The column count
 
-.. c:function:: uint64_t drizzle_result_row_count(drizzle_result_st *result)
+.. c:function:: uint64_t drizzle_result_row_count(const drizzle_result_st *result)
 
    Gets the row count from a result set buffered with
    :c:func:`drizzle_result_buffer`
@@ -174,7 +174,7 @@ Functions
    :param result: A result object
    :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
 
-.. c:function:: size_t drizzle_result_row_size(drizzle_result_st *result)
+.. c:function:: size_t drizzle_result_row_size(const drizzle_result_st *result)
 
    Get result row packet size in bytes.
 
@@ -188,98 +188,98 @@ Functions
    :param column: A column object
    :returns: A result object
 
-.. c:function:: const char* drizzle_column_catalog(drizzle_column_st *column)
+.. c:function:: const char* drizzle_column_catalog(const drizzle_column_st *column)
 
    Gets the catalog name for a given column
 
    :param column: A column object
    :returns: The catalog name
 
-.. c:function:: const char* drizzle_column_db(drizzle_column_st *column)
+.. c:function:: const char* drizzle_column_db(const drizzle_column_st *column)
 
    Gets the database name for a given column
 
    :param column: A column object
    :returns: The database name
 
-.. c:function:: const char* drizzle_column_table(drizzle_column_st *column)
+.. c:function:: const char* drizzle_column_table(const drizzle_column_st *column)
 
    Get the table name (or table alias) for a given column
 
    :param column: A column object
    :returns: The table name
 
-.. c:function:: const char* drizzle_column_orig_table(drizzle_column_st *column)
+.. c:function:: const char* drizzle_column_orig_table(const drizzle_column_st *column)
 
    Gets the original table name (if an alias has been used) for a given column
 
    :param column: A column object
    :returns: The original table name
 
-.. c:function:: const char* drizzle_column_name(drizzle_column_st *column)
+.. c:function:: const char* drizzle_column_name(const drizzle_column_st *column)
 
    Gets the column name (or column alias) for a given column
 
    :param column: A column object
    :returns: The column name
 
-.. c:function:: const char* drizzle_column_orig_name(drizzle_column_st *column)
+.. c:function:: const char* drizzle_column_orig_name(const drizzle_column_st *column)
 
    Gets the original column name (if an alias has been used) for a given column
 
    :param column: A column object
    :returns: The original column name
 
-.. c:function:: drizzle_charset_t drizzle_column_charset(drizzle_column_st *column)
+.. c:function:: drizzle_charset_t drizzle_column_charset(const drizzle_column_st *column)
 
    Gets the character set ID for a given column
 
    :param column: A column object
    :returns: The character set ID
 
-.. c:function:: uint32_t drizzle_column_size(drizzle_column_st *column)
+.. c:function:: uint32_t drizzle_column_size(const drizzle_column_st *column)
 
    Gets the size of a given column
 
    :param column: A column object
    :returns: The column size
 
-.. c:function:: size_t drizzle_column_max_size(drizzle_column_st *column)
+.. c:function:: size_t drizzle_column_max_size(const drizzle_column_st *column)
 
    Gets the maximum size of a given column
 
    :param column: A column object
    :returns: The maximum size
 
-.. c:function:: drizzle_column_type_t drizzle_column_type(drizzle_column_st *column)
+.. c:function:: drizzle_column_type_t drizzle_column_type(const drizzle_column_st *column)
 
    Gets the type of data for the column
 
    :param column: A column object
    :returns: The column type
 
-.. c:function:: const char *drizzle_column_type_str(drizzle_column_type_t type)
+.. c:function:: const char *drizzle_column_type_str(const drizzle_column_type_t type)
 
    Get a column type as string
 
    :param type: The table column type
    :returns: The type of the column in human readable format
 
-.. c:function:: drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column)
+.. c:function:: drizzle_column_flags_t drizzle_column_flags(const drizzle_column_st *column))
 
    Gets the flags for a given column
 
    :param column: A column object
    :returns: The column flags
 
-.. c:function:: uint8_t drizzle_column_decimals(drizzle_column_st *column)
+.. c:function:: uint8_t drizzle_column_decimals(const drizzle_column_st *column)
 
    Gets the number of decimal places for a given column
 
    :param column: A column object
    :returns: The number of decimal places
 
-.. c:function:: const unsigned char* drizzle_column_default_value(drizzle_column_st *column, size_t *size)
+.. c:function:: const unsigned char* drizzle_column_default_value(const drizzle_column_st *column, size_t *size)
 
    Gets the default value for a given column
 
@@ -346,7 +346,7 @@ Functions
    :param result: A result object
    :param column: The column number
 
-.. c:function:: drizzle_column_st* drizzle_column_index(drizzle_result_st *result, uint16_t column)
+.. c:function:: drizzle_column_st* drizzle_column_index(const drizzle_result_st *result, uint16_t column)
 
    Gets a given column in a column buffered result set
 
@@ -354,7 +354,7 @@ Functions
    :param column: The column number
    :returns: A column object
 
-.. c:function:: uint16_t drizzle_column_current(drizzle_result_st *result)
+.. c:function:: uint16_t drizzle_column_current(const drizzle_result_st *result)
 
    Gets the column number in a buffered or unbuffered column result set
 
@@ -386,7 +386,7 @@ Functions
    :param result: A result object
    :param row: The row data to be freed
 
-.. c:function:: size_t* drizzle_row_field_sizes(drizzle_result_st *result)
+.. c:function:: size_t* drizzle_row_field_sizes(const drizzle_result_st *result)
 
    Gets an array of the field sizes for buffered rows
 
@@ -414,7 +414,7 @@ Functions
    :param result: A result object
    :param row: The row number to seek to
 
-.. c:function:: drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row)
+.. c:function:: drizzle_row_t drizzle_row_indexc(const drizzle_result_st *result, uint64_t row)
 
    Gets a row at the given index in a buffered result set
 
@@ -422,7 +422,7 @@ Functions
    :param row: The row number to get
    :returns: The row data
 
-.. c:function:: uint64_t drizzle_row_current(drizzle_result_st *result)
+.. c:function:: uint64_t drizzle_row_current(const drizzle_result_st *result)
 
    Gets the current row number
 

--- a/docs/api/statement.rst
+++ b/docs/api/statement.rst
@@ -174,7 +174,7 @@ Functions
    :param stmt: The prepared statement object
    :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
 
-.. c:function:: bool drizzle_stmt_get_is_null(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+.. c:function:: bool drizzle_stmt_get_is_null(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
    Check if a column for a fetched row is set to NULL
 
@@ -183,7 +183,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into
    :returns: True if NULL
 
-.. c:function:: bool drizzle_stmt_get_is_null_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+.. c:function:: bool drizzle_stmt_get_is_null_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
    Check if a column for a fetched row is set to NULL using a column name
 
@@ -192,7 +192,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into, :py:const:`DRIZZLE_RETURN_NOT_FOUND` if the column name cannot be found
    :returns: True if NULL
 
-.. c:function:: bool drizzle_stmt_get_is_unsigned(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+.. c:function:: bool drizzle_stmt_get_is_unsigned(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
    Check if a column for a fetched row is unsigned
 
@@ -201,7 +201,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into
    :returns: True if unsigned
 
-.. c:function:: bool drizzle_stmt_get_is_unsigned_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+.. c:function:: bool drizzle_stmt_get_is_unsigned_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
    Check if a column for a fetched row is unsigned using a column name
 
@@ -210,7 +210,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into, :py:const:`DRIZZLE_RETURN_NOT_FOUND` if the column name cannot be found
    :returns: True if unsigned
 
-.. c:function:: const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr)
+.. c:function:: const char *drizzle_stmt_get_string(const drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr)
 
    Get the string value for a column of a fetched row (int types are automatically converted)
 
@@ -220,7 +220,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into
    :returns: A pointer to the string value
 
-.. c:function:: const char *drizzle_stmt_get_string_from_name(drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
+.. c:function:: const char *drizzle_stmt_get_string_from_name(const drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
 
    Get the string value for a column of a fetched row (int types are automatically converted) using a column name
 
@@ -230,7 +230,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into, :py:const:`DRIZZLE_RETURN_NOT_FOUND` if the column name cannot be found
    :returns: A pointer to the string value
 
-.. c:function:: uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+.. c:function:: uint32_t drizzle_stmt_get_int(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
    Get the int value for a column of a fetched row
 
@@ -239,7 +239,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into :py:const:`DRIZZLE_RETURN_TRUNCATED` if a truncation has occurred
    :returns: The int value
 
-.. c:function:: uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+.. c:function:: uint32_t drizzle_stmt_get_int_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
    Get the int value for a column of a fetched row using a column name
 
@@ -248,7 +248,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into :py:const:`DRIZZLE_RETURN_TRUNCATED` if a truncation has occurred,  :py:const:`DRIZZLE_RETURN_NOT_FOUND` if the column name cannot be found
    :returns: The int value
 
-.. c:function:: uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+.. c:function:: uint64_t drizzle_stmt_get_bigint(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
    Get the bigint value for a column of a fetched row
 
@@ -257,7 +257,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into :py:const:`DRIZZLE_RETURN_TRUNCATED` if a truncation has occurred
    :returns: The bigint value
 
-.. c:function:: uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+.. c:function:: uint64_t drizzle_stmt_get_bigint_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
    Get the bigint value for a column of a fetched row using a column name
 
@@ -266,7 +266,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into :py:const:`DRIZZLE_RETURN_TRUNCATED` if a truncation has occurred,  :py:const:`DRIZZLE_RETURN_NOT_FOUND` if the column name cannot be found
    :returns: The bigint value
 
-.. c:function:: double drizzle_stmt_get_double(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+.. c:function:: double drizzle_stmt_get_double(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
    Get the double value for a column of a fetched row
 
@@ -275,7 +275,7 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into :py:const:`DRIZZLE_RETURN_TRUNCATED` if a truncation has occurred
    :returns: The double value
 
-.. c:function:: double drizzle_stmt_get_double_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+.. c:function:: double drizzle_stmt_get_double_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
    Get the double value for a column of a fetched row from a column name
 
@@ -291,35 +291,35 @@ Functions
    :param stmt: The prepared statement object
    :returns: A return status code, :py:const:`DRIZZLE_RETURN_OK` upon success
 
-.. c:function:: uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt)
+.. c:function:: uint16_t drizzle_stmt_column_count(const drizzle_stmt_st *stmt)
 
    Gets the column count for a result set which has been executed using :c:func:`drizzle_stmt_execute`
 
    :param stmt: The prepared statement object
    :returns: The column count
 
-.. c:function:: uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt)
+.. c:function:: uint64_t drizzle_stmt_affected_rows(const drizzle_stmt_st *stmt)
 
    Gets the affected rows count for a result set which has been executed using :c:func:`drizzle_stmt_execute`
 
    :param stmt: The prepared statement object
    :returns: The column count
 
-.. c:function:: uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt)
+.. c:function:: uint64_t drizzle_stmt_insert_id(const drizzle_stmt_st *stmt)
 
    Gets the insert ID for a result set which has been executed using :c:func:`drizzle_stmt_execute`
 
    :param stmt: The prepared statement object
    :returns: The insert ID
 
-.. c:function:: uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt)
+.. c:function:: uint16_t drizzle_stmt_param_count(const drizzle_stmt_st *stmt)
 
    Gets the number of parameters expected for a result set that has been prepared with :c:func:`drizzle_stmt_prepare`
 
    :param stmt: The prepared statement object
    :returns: The number of parameters
 
-.. c:function:: uint64_t drizzle_stmt_row_count(drizzle_stmt_st *stmt)
+.. c:function:: uint64_t drizzle_stmt_row_count(const drizzle_stmt_st *stmt)
 
    Gets the row count for a statement buffered with :c:func:`drizzle_stmt_buffer`
 

--- a/include/libdrizzle-redux/binlog.h
+++ b/include/libdrizzle-redux/binlog.h
@@ -107,7 +107,7 @@ drizzle_return_t drizzle_binlog_start(drizzle_binlog_st *binlog,
 * @return The timestamp for the binlog event
 */
 DRIZZLE_API
-uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event);
+uint32_t drizzle_binlog_event_timestamp(const drizzle_binlog_event_st *event);
 
 /**
 * Get the event type for the event received by the event callback
@@ -116,7 +116,7 @@ uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event);
 * @return The event type of the binlog event
 */
 DRIZZLE_API
-drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *event);
+drizzle_binlog_event_types_t drizzle_binlog_event_type(const drizzle_binlog_event_st *event);
 
 /**
 * Get the server_id for the event received by the event callback
@@ -125,7 +125,7 @@ drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *
 * @return The server_id for the binlog event
 */
 DRIZZLE_API
-uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event);
+uint32_t drizzle_binlog_event_server_id(const drizzle_binlog_event_st *event);
 
 /**
 * Get the length of the event data (excluding header) received by the event
@@ -135,7 +135,7 @@ uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event);
 * @return The event data length
 */
 DRIZZLE_API
-uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event);
+uint32_t drizzle_binlog_event_length(const drizzle_binlog_event_st *event);
 
 /**
 * Get the next event position from the event received by the event callback
@@ -144,7 +144,7 @@ uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event);
 * @return The next event position
 */
 DRIZZLE_API
-uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event);
+uint32_t drizzle_binlog_event_next_pos(const drizzle_binlog_event_st *event);
 
 /**
 * Get the flags for the event received by the event callback
@@ -153,7 +153,7 @@ uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event);
 * @return The event flags
 */
 DRIZZLE_API
-uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event);
+uint16_t drizzle_binlog_event_flags(const drizzle_binlog_event_st *event);
 
 /**
 * Get the flags for the event received by the event callback
@@ -162,7 +162,7 @@ uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event);
 * @return The extra event flags
 */
 DRIZZLE_API
-uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event);
+uint16_t drizzle_binlog_event_extra_flags(const drizzle_binlog_event_st *event);
 
 /**
 * Get the event data for the event received by the event callback
@@ -171,7 +171,7 @@ uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event);
 * @return A pointer to the event data
 */
 DRIZZLE_API
-const unsigned char *drizzle_binlog_event_data(drizzle_binlog_event_st *event);
+const unsigned char *drizzle_binlog_event_data(const drizzle_binlog_event_st *event);
 
 /**
 * Get the raw event data (including header) for the event received by the event
@@ -181,7 +181,7 @@ const unsigned char *drizzle_binlog_event_data(drizzle_binlog_event_st *event);
 * @return A pointer to the raw event data
 */
 DRIZZLE_API
-const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *event);
+const unsigned char *drizzle_binlog_event_raw_data(const drizzle_binlog_event_st *event);
 
 /**
 * Get the length of the raw event data (including header) for the event
@@ -191,7 +191,7 @@ const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *even
 * @return The length of the raw event data
 */
 DRIZZLE_API
-uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event);
+uint32_t drizzle_binlog_event_raw_length(const drizzle_binlog_event_st *event);
 
 /**
 * Get the event type for the binlog event as string
@@ -200,7 +200,7 @@ uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event);
 * @return The event type of the binlog event as string
 */
 DRIZZLE_API
-const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type);
+const char *drizzle_binlog_event_type_str(const drizzle_binlog_event_types_t event_type);
 
 /**
  * Get the name and size of a binlog file in bytes

--- a/include/libdrizzle-redux/column.h
+++ b/include/libdrizzle-redux/column.h
@@ -74,61 +74,61 @@ drizzle_result_st *drizzle_column_drizzle_result(drizzle_column_st *column);
  * Get catalog name for a column.
  */
 DRIZZLE_API
-const char *drizzle_column_catalog(drizzle_column_st *column);
+const char *drizzle_column_catalog(const drizzle_column_st *column);
 
 /**
  * Get database name for a column.
  */
 DRIZZLE_API
-const char *drizzle_column_db(drizzle_column_st *column);
+const char *drizzle_column_db(const drizzle_column_st *column);
 
 /**
  * Get table name for a column.
  */
 DRIZZLE_API
-const char *drizzle_column_table(drizzle_column_st *column);
+const char *drizzle_column_table(const drizzle_column_st *column);
 
 /**
  * Get original table name for a column.
  */
 DRIZZLE_API
-const char *drizzle_column_orig_table(drizzle_column_st *column);
+const char *drizzle_column_orig_table(const drizzle_column_st *column);
 
 /**
  * Get column name for a column.
  */
 DRIZZLE_API
-const char *drizzle_column_name(drizzle_column_st *column);
+const char *drizzle_column_name(const drizzle_column_st *column);
 
 /**
  * Get original column name for a column.
  */
 DRIZZLE_API
-const char *drizzle_column_orig_name(drizzle_column_st *column);
+const char *drizzle_column_orig_name(const drizzle_column_st *column);
 
 /**
  * Get charset for a column.
  */
 DRIZZLE_API
-drizzle_charset_t drizzle_column_charset(drizzle_column_st *column);
+drizzle_charset_t drizzle_column_charset(const drizzle_column_st *column);
 
 /**
  * Get size of a column.
  */
 DRIZZLE_API
-uint32_t drizzle_column_size(drizzle_column_st *column);
+uint32_t drizzle_column_size(const drizzle_column_st *column);
 
 /**
  * Get max size of a column.
  */
 DRIZZLE_API
-size_t drizzle_column_max_size(drizzle_column_st *column);
+size_t drizzle_column_max_size(const drizzle_column_st *column);
 
 /**
  * Get the type of a column.
  */
 DRIZZLE_API
-drizzle_column_type_t drizzle_column_type(drizzle_column_st *column);
+drizzle_column_type_t drizzle_column_type(const drizzle_column_st *column);
 
 /**
  * Get a column type as string
@@ -137,25 +137,25 @@ drizzle_column_type_t drizzle_column_type(drizzle_column_st *column);
  * @return The type of the column in human readable format
  */
 DRIZZLE_API
-const char *drizzle_column_type_str(drizzle_column_type_t type);
+const char *drizzle_column_type_str(const drizzle_column_type_t type);
 
 /**
  * Get flags for a column.
  */
 DRIZZLE_API
-drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column);
+drizzle_column_flags_t drizzle_column_flags(const drizzle_column_st *column);
 
 /**
  * Get the number of decimals for numeric columns.
  */
 DRIZZLE_API
-uint8_t drizzle_column_decimals(drizzle_column_st *column);
+uint8_t drizzle_column_decimals(const drizzle_column_st *column);
 
 /**
  * Get default value for a column.
  */
 DRIZZLE_API
-const unsigned char *drizzle_column_default_value(drizzle_column_st *column,
+const unsigned char *drizzle_column_default_value(const drizzle_column_st *column,
                                             size_t *size);
 
 /** @} */

--- a/include/libdrizzle-redux/column_client.h
+++ b/include/libdrizzle-redux/column_client.h
@@ -131,7 +131,7 @@ void drizzle_column_seek(drizzle_result_st *result, uint16_t column);
  * @return A column object
  */
 DRIZZLE_API
-drizzle_column_st *drizzle_column_index(drizzle_result_st *result,
+drizzle_column_st *drizzle_column_index(const drizzle_result_st *result,
                                         uint16_t column);
 
 /**
@@ -141,7 +141,7 @@ drizzle_column_st *drizzle_column_index(drizzle_result_st *result,
  * @return        The column number
  */
 DRIZZLE_API
-uint16_t drizzle_column_current(drizzle_result_st *result);
+uint16_t drizzle_column_current(const drizzle_result_st *result);
 
 /** @} */
 

--- a/include/libdrizzle-redux/conn.h
+++ b/include/libdrizzle-redux/conn.h
@@ -184,7 +184,7 @@ void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option_t option,
  * @return The value of the option, or -1 if the specified option doesn't exist
  */
 DRIZZLE_API
-int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option);
+int drizzle_socket_get_option(const drizzle_st *con, drizzle_socket_option_t option);
 
 /**
  * Sets/unsets non-blocking connect option
@@ -202,7 +202,7 @@ void drizzle_options_set_non_blocking(drizzle_options_st *options, bool state);
  * @return The state of the non-blocking option
  */
 DRIZZLE_API
-bool drizzle_options_get_non_blocking(drizzle_options_st *options);
+bool drizzle_options_get_non_blocking(const drizzle_options_st *options);
 
 /**
  * Sets/unsets the raw scramble connect option
@@ -220,7 +220,7 @@ void drizzle_options_set_raw_scramble(drizzle_options_st *options, bool state);
  * @return The state of the raw scramble option
  */
 DRIZZLE_API
-bool drizzle_options_get_raw_scramble(drizzle_options_st *options);
+bool drizzle_options_get_raw_scramble(const drizzle_options_st *options);
 
 /**
  * Sets/unsets the found rows connect option
@@ -238,7 +238,7 @@ void drizzle_options_set_found_rows(drizzle_options_st *options, bool state);
  * @return The state of the found rows option
  */
 DRIZZLE_API
-bool drizzle_options_get_found_rows(drizzle_options_st *options);
+bool drizzle_options_get_found_rows(const drizzle_options_st *options);
 
 /**
  * Sets/unsets the interactive connect option
@@ -256,7 +256,7 @@ void drizzle_options_set_interactive(drizzle_options_st *options, bool state);
  * @return The state of the interactive option
  */
 DRIZZLE_API
-bool drizzle_options_get_interactive(drizzle_options_st *options);
+bool drizzle_options_get_interactive(const drizzle_options_st *options);
 
 /**
  * Sets/unsets the multi-statements connect option
@@ -274,7 +274,7 @@ void drizzle_options_set_multi_statements(drizzle_options_st *options, bool stat
  * @return The state of the multi-statements option
  */
 DRIZZLE_API
-bool drizzle_options_get_multi_statements(drizzle_options_st *options);
+bool drizzle_options_get_multi_statements(const drizzle_options_st *options);
 
 /**
  * Sets/unsets the auth plugin connect option
@@ -292,7 +292,7 @@ void drizzle_options_set_auth_plugin(drizzle_options_st *options, bool state);
  * @return The state of the auth plugin option
  */
 DRIZZLE_API
-bool drizzle_options_get_auth_plugin(drizzle_options_st *options);
+bool drizzle_options_get_auth_plugin(const drizzle_options_st *options);
 
 /**
  * Sets the owner of the socket connection
@@ -311,7 +311,7 @@ void drizzle_options_set_socket_owner(drizzle_options_st *options,
  * @return The owner of the socket
  */
 DRIZZLE_API
-drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options);
+drizzle_socket_owner_t drizzle_options_get_socket_owner(const drizzle_options_st *options);
 
 /**
  * Get TCP host for a connection.

--- a/include/libdrizzle-redux/constants.h
+++ b/include/libdrizzle-redux/constants.h
@@ -598,7 +598,7 @@ typedef drizzle_field_t *drizzle_row_t;
 
 typedef void (drizzle_log_fn)(const char *file, uint line, const char *func,
   const char *msg, drizzle_verbose_t verbose, void *context);
-typedef void (drizzle_binlog_fn)(drizzle_binlog_event_st *event, void *context);
+typedef void (drizzle_binlog_fn)(const drizzle_binlog_event_st *event, void *context);
 typedef void (drizzle_binlog_error_fn)(drizzle_return_t error, drizzle_st *con, void *context);
 typedef drizzle_return_t (drizzle_state_fn)(drizzle_st *con);
 typedef void (drizzle_context_free_fn)(drizzle_st *con,

--- a/include/libdrizzle-redux/drizzle.h
+++ b/include/libdrizzle-redux/drizzle.h
@@ -106,7 +106,7 @@ const char *drizzle_bugreport(void);
  * @return String form of verbose level.
  */
 DRIZZLE_API
-const char *drizzle_verbose_name(drizzle_verbose_t verbose);
+const char *drizzle_verbose_name(const drizzle_verbose_t verbose);
 
 /**
  * Get current socket I/O activity timeout value.

--- a/include/libdrizzle-redux/query.h
+++ b/include/libdrizzle-redux/query.h
@@ -87,7 +87,7 @@ drizzle_result_st *drizzle_query(drizzle_st *con,
  *         parameters or overflow
  */
 DRIZZLE_API
-ssize_t drizzle_escape_string(drizzle_st *con, char **to, const char *from, const size_t from_size);
+ssize_t drizzle_escape_string(const drizzle_st *con, char **to, const char *from, const size_t from_size);
 
 /**
  * Escape a string for an SQL query, optionally for pattern matching.
@@ -115,7 +115,7 @@ ssize_t drizzle_escape_string(drizzle_st *con, char **to, const char *from, cons
  *         parameters or overflow
  */
 DRIZZLE_API
-ssize_t drizzle_escape_str(drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern);
+ssize_t drizzle_escape_str(const drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern);
 
 /** @} */
 

--- a/include/libdrizzle-redux/result.h
+++ b/include/libdrizzle-redux/result.h
@@ -87,7 +87,7 @@ drizzle_st *drizzle_result_drizzle_con(drizzle_result_st *result);
  * @return true on EOF else false
  */
 DRIZZLE_API
-bool drizzle_result_eof(drizzle_result_st *result);
+bool drizzle_result_eof(const drizzle_result_st *result);
 
 /**
  * Get error or information message from result set
@@ -96,7 +96,7 @@ bool drizzle_result_eof(drizzle_result_st *result);
  * @return The message to be returned
  */
 DRIZZLE_API
-const char *drizzle_result_message(drizzle_result_st *result);
+const char *drizzle_result_message(const drizzle_result_st *result);
 
 /**
  * Gets the error code from a result set
@@ -105,7 +105,7 @@ const char *drizzle_result_message(drizzle_result_st *result);
  * @return The error code
  */
 DRIZZLE_API
-uint16_t drizzle_result_error_code(drizzle_result_st *result);
+uint16_t drizzle_result_error_code(const drizzle_result_st *result);
 
 /**
  * Gets the SQL state from a result set
@@ -114,7 +114,7 @@ uint16_t drizzle_result_error_code(drizzle_result_st *result);
  * @return The SQL state string
  */
 DRIZZLE_API
-const char *drizzle_result_sqlstate(drizzle_result_st *result);
+const char *drizzle_result_sqlstate(const drizzle_result_st *result);
 
 /**
   * Gets the warning count from a result set
@@ -123,7 +123,7 @@ const char *drizzle_result_sqlstate(drizzle_result_st *result);
  * @return The warning count
  */
 DRIZZLE_API
-uint16_t drizzle_result_warning_count(drizzle_result_st *result);
+uint16_t drizzle_result_warning_count(const drizzle_result_st *result);
 
 /**
  * Gets the insert ID for an auto_increment column in a result set
@@ -132,7 +132,7 @@ uint16_t drizzle_result_warning_count(drizzle_result_st *result);
  * @return The inserted ID
  */
 DRIZZLE_API
-uint64_t drizzle_result_insert_id(drizzle_result_st *result);
+uint64_t drizzle_result_insert_id(const drizzle_result_st *result);
 
 /**
  * Gets the affected row count from a result set
@@ -141,7 +141,7 @@ uint64_t drizzle_result_insert_id(drizzle_result_st *result);
  * @return The affected row count
  */
 DRIZZLE_API
-uint64_t drizzle_result_affected_rows(drizzle_result_st *result);
+uint64_t drizzle_result_affected_rows(const drizzle_result_st *result);
 
 /**
  * Gets the column count from a result set
@@ -150,7 +150,7 @@ uint64_t drizzle_result_affected_rows(drizzle_result_st *result);
  * @return The column count
  */
 DRIZZLE_API
-uint16_t drizzle_result_column_count(drizzle_result_st *result);
+uint16_t drizzle_result_column_count(const drizzle_result_st *result);
 
 /**
  * Gets the row count from a result set buffered with drizzle_result_buffer()
@@ -159,7 +159,7 @@ uint16_t drizzle_result_column_count(drizzle_result_st *result);
  * @return The row count
  */
 DRIZZLE_API
-uint64_t drizzle_result_row_count(drizzle_result_st *result);
+uint64_t drizzle_result_row_count(const drizzle_result_st *result);
 
 /** @} */
 

--- a/include/libdrizzle-redux/result_client.h
+++ b/include/libdrizzle-redux/result_client.h
@@ -82,7 +82,7 @@ drizzle_return_t drizzle_result_buffer(drizzle_result_st *result);
  * @return size in bytes else 0
  */
 DRIZZLE_API
-size_t drizzle_result_row_size(drizzle_result_st *result);
+size_t drizzle_result_row_size(const drizzle_result_st *result);
 
 /** @} */
 

--- a/include/libdrizzle-redux/return.h
+++ b/include/libdrizzle-redux/return.h
@@ -88,7 +88,7 @@ typedef enum drizzle_return_t drizzle_return_t;
 * @param[in] ret result code
 * @return true on success, false otherwise
 */
-static inline bool drizzle_success(drizzle_return_t ret)
+static inline bool drizzle_success(const drizzle_return_t ret)
 {
   if (ret == DRIZZLE_RETURN_OK)
   {
@@ -104,7 +104,7 @@ static inline bool drizzle_success(drizzle_return_t ret)
 * @param[in] ret result code
 * @return true on fail, false otherwise
 */
-static inline bool drizzle_failed(drizzle_return_t ret)
+static inline bool drizzle_failed(const drizzle_return_t ret)
 {
   if (ret != DRIZZLE_RETURN_OK)
   {

--- a/include/libdrizzle-redux/row_client.h
+++ b/include/libdrizzle-redux/row_client.h
@@ -98,7 +98,7 @@ void drizzle_row_free(drizzle_result_st *result, drizzle_row_t row);
  * @return An array of row sizes
  */
 DRIZZLE_API
-size_t *drizzle_row_field_sizes(drizzle_result_st *result);
+size_t *drizzle_row_field_sizes(const drizzle_result_st *result);
 
 /**
  * Gets the next row in a buffered result set
@@ -135,7 +135,7 @@ void drizzle_row_seek(drizzle_result_st *result, uint64_t row);
  * @return The row data
  */
 DRIZZLE_API
-drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row);
+drizzle_row_t drizzle_row_index(const drizzle_result_st *result, uint64_t row);
 
 /**
  * Gets the current row number
@@ -144,7 +144,7 @@ drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row);
  * @return The row number
  */
 DRIZZLE_API
-uint64_t drizzle_row_current(drizzle_result_st *result);
+uint64_t drizzle_row_current(const drizzle_result_st *result);
 
 /** @} */
 

--- a/include/libdrizzle-redux/statement.h
+++ b/include/libdrizzle-redux/statement.h
@@ -122,7 +122,7 @@ drizzle_return_t drizzle_stmt_close(drizzle_stmt_st *stmt);
  * @return The column count
  */
 DRIZZLE_API
-uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt);
+uint16_t drizzle_stmt_column_count(const drizzle_stmt_st *stmt);
 
 /**
  * Gets the affected rows count for a result set which has been executed using
@@ -132,7 +132,7 @@ uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt);
  * @return The column count
  */
 DRIZZLE_API
-uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt);
+uint64_t drizzle_stmt_affected_rows(const drizzle_stmt_st *stmt);
 
 /**
  * Gets the insert ID for a result set which has been executed using drizzle_stmt_execute
@@ -141,7 +141,7 @@ uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt);
  * @return The insert ID
  */
 DRIZZLE_API
-uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt);
+uint64_t drizzle_stmt_insert_id(const drizzle_stmt_st *stmt);
 
 /**
  * Gets the number of parameters expected for a result set that has been
@@ -151,7 +151,7 @@ uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt);
  * @return The number of parameters
  */
 DRIZZLE_API
-uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt);
+uint16_t drizzle_stmt_param_count(const drizzle_stmt_st *stmt);
 
 /** Gets the row count for a statement buffered with drizzle_stmt_buffer
  * n error it returns UINT64_MAX;
@@ -160,7 +160,7 @@ uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt);
  * @return The row count
  */
 DRIZZLE_API
-uint64_t drizzle_stmt_row_count(drizzle_stmt_st *stmt);
+uint64_t drizzle_stmt_row_count(const drizzle_stmt_st *stmt);
 
 /**
  *Sets a parameter of a prepared statement to a tinyint value
@@ -310,7 +310,7 @@ drizzle_return_t drizzle_stmt_set_timestamp(drizzle_stmt_st *stmt, uint16_t para
  * @return True if NULL
  */
 DRIZZLE_API
-bool drizzle_stmt_get_is_null_from_name(drizzle_stmt_st *stmt,
+bool drizzle_stmt_get_is_null_from_name(const drizzle_stmt_st *stmt,
                                         const char *column_name,
                                         drizzle_return_t *ret_ptr);
 
@@ -323,7 +323,7 @@ bool drizzle_stmt_get_is_null_from_name(drizzle_stmt_st *stmt,
  * @return True if NULL
  */
 DRIZZLE_API
-bool drizzle_stmt_get_is_null(drizzle_stmt_st *stmt, uint16_t column_number,
+bool drizzle_stmt_get_is_null(const drizzle_stmt_st *stmt, uint16_t column_number,
                               drizzle_return_t *ret_ptr);
 
 /**
@@ -336,7 +336,7 @@ bool drizzle_stmt_get_is_null(drizzle_stmt_st *stmt, uint16_t column_number,
  * @return True if unsigned
 */
 DRIZZLE_API
-bool drizzle_stmt_get_is_unsigned_from_name(drizzle_stmt_st *stmt,
+bool drizzle_stmt_get_is_unsigned_from_name(const drizzle_stmt_st *stmt,
                                             const char *column_name,
                                             drizzle_return_t *ret_ptr);
 
@@ -349,7 +349,7 @@ bool drizzle_stmt_get_is_unsigned_from_name(drizzle_stmt_st *stmt,
  * @return True if unsigned
  */
 DRIZZLE_API
-bool drizzle_stmt_get_is_unsigned(drizzle_stmt_st *stmt, uint16_t column_number,
+bool drizzle_stmt_get_is_unsigned(const drizzle_stmt_st *stmt, uint16_t column_number,
                                   drizzle_return_t *ret_ptr);
 
 /**
@@ -364,7 +364,7 @@ bool drizzle_stmt_get_is_unsigned(drizzle_stmt_st *stmt, uint16_t column_number,
  * @return A pointer to the string value
  */
 DRIZZLE_API
-const char *drizzle_stmt_get_string_from_name(drizzle_stmt_st *stmt,
+const char *drizzle_stmt_get_string_from_name(const drizzle_stmt_st *stmt,
                                               const char *column_name,
                                               size_t *len, drizzle_return_t *ret_ptr);
 
@@ -379,7 +379,7 @@ const char *drizzle_stmt_get_string_from_name(drizzle_stmt_st *stmt,
  * @return A pointer to the string value
  */
 DRIZZLE_API
-const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_number,
+const char *drizzle_stmt_get_string(const drizzle_stmt_st *stmt, uint16_t column_number,
                                     size_t *len, drizzle_return_t *ret_ptr);
 
 /**
@@ -392,7 +392,7 @@ const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_numbe
  * @return The int value
  */
 DRIZZLE_API
-uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number,
+uint32_t drizzle_stmt_get_int(const drizzle_stmt_st *stmt, uint16_t column_number,
                               drizzle_return_t *ret_ptr);
 
 /**
@@ -406,7 +406,7 @@ uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number,
  * @return The int value
  */
 DRIZZLE_API
-uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *column_name,
+uint32_t drizzle_stmt_get_int_from_name(const drizzle_stmt_st *stmt, const char *column_name,
                                         drizzle_return_t *ret_ptr);
 
 /**
@@ -420,7 +420,7 @@ uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *colum
  * @return The bigint value
  */
 DRIZZLE_API
-uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name,
+uint64_t drizzle_stmt_get_bigint_from_name(const drizzle_stmt_st *stmt, const char *column_name,
                                            drizzle_return_t *ret_ptr);
 
 /**
@@ -433,7 +433,7 @@ uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *co
  * @return The bigint value
  */
 DRIZZLE_API
-uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number,
+uint64_t drizzle_stmt_get_bigint(const drizzle_stmt_st *stmt, uint16_t column_number,
                                  drizzle_return_t *ret_ptr);
 /**
  * Get the double value for a column of a fetched row
@@ -445,7 +445,7 @@ uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number,
  * @return The double value
  */
 DRIZZLE_API
-double drizzle_stmt_get_double(drizzle_stmt_st *stmt, uint16_t column_number,
+double drizzle_stmt_get_double(const drizzle_stmt_st *stmt, uint16_t column_number,
                                drizzle_return_t *ret_ptr);
 
 /**
@@ -459,7 +459,7 @@ double drizzle_stmt_get_double(drizzle_stmt_st *stmt, uint16_t column_number,
  * @return The double value
  */
 DRIZZLE_API
-double drizzle_stmt_get_double_from_name(drizzle_stmt_st *stmt, const char *column_name,
+double drizzle_stmt_get_double_from_name(const drizzle_stmt_st *stmt, const char *column_name,
                                          drizzle_return_t *ret_ptr);
 
 #ifdef __cplusplus

--- a/relnotes/const-qualifier.feature.md
+++ b/relnotes/const-qualifier.feature.md
@@ -1,0 +1,270 @@
+### Add const qualifier to params for non-mutating functions
+
+- `include/libdrizzle-redux/binlog.h`
+
+```diff
+
+-uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event);
++uint32_t drizzle_binlog_event_timestamp(const drizzle_binlog_event_st *event);
+
+-drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *event);
++drizzle_binlog_event_types_t drizzle_binlog_event_type(const drizzle_binlog_event_st *event);
+
+-uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event);
++uint32_t drizzle_binlog_event_server_id(const drizzle_binlog_event_st *event);
+
+-uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event);
++uint32_t drizzle_binlog_event_length(const drizzle_binlog_event_st *event);
+
+-uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event);
++uint32_t drizzle_binlog_event_next_pos(const drizzle_binlog_event_st *event);
+
+-uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event);
++uint16_t drizzle_binlog_event_flags(const drizzle_binlog_event_st *event);
+
+-uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event);
++uint16_t drizzle_binlog_event_extra_flags(const drizzle_binlog_event_st *event);
+
+-const unsigned char *drizzle_binlog_event_data(drizzle_binlog_event_st *event);
++const unsigned char *drizzle_binlog_event_data(const drizzle_binlog_event_st *event);
+
+-const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *event);
++const unsigned char *drizzle_binlog_event_raw_data(const drizzle_binlog_event_st *event);
+
+-uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event);
++uint32_t drizzle_binlog_event_raw_length(const drizzle_binlog_event_st *event);
+
+-const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type);
++const char *drizzle_binlog_event_type_str(const drizzle_binlog_event_types_t event_type);
+
+```
+
+- `include/libdrizzle-redux/column.h`
+
+```diff
+
+-const char *drizzle_column_catalog(drizzle_column_st *column);
++const char *drizzle_column_catalog(const drizzle_column_st *column);
+
+-const char *drizzle_column_db(drizzle_column_st *column);
++const char *drizzle_column_db(const drizzle_column_st *column);
+
+-const char *drizzle_column_table(drizzle_column_st *column);
++const char *drizzle_column_table(const drizzle_column_st *column);
+
+-const char *drizzle_column_orig_table(drizzle_column_st *column);
++const char *drizzle_column_orig_table(const drizzle_column_st *column);
+
+-const char *drizzle_column_name(drizzle_column_st *column);
++const char *drizzle_column_name(const drizzle_column_st *column);
+
+-const char *drizzle_column_orig_name(drizzle_column_st *column);
++const char *drizzle_column_orig_name(const drizzle_column_st *column);
+
+-drizzle_charset_t drizzle_column_charset(drizzle_column_st *column);
++drizzle_charset_t drizzle_column_charset(const drizzle_column_st *column);
+
+-uint32_t drizzle_column_size(drizzle_column_st *column);
++uint32_t drizzle_column_size(const drizzle_column_st *column);
+
+-size_t drizzle_column_max_size(drizzle_column_st *column);
++size_t drizzle_column_max_size(const drizzle_column_st *column);
+
+-drizzle_column_type_t drizzle_column_type(drizzle_column_st *column);
++drizzle_column_type_t drizzle_column_type(const drizzle_column_st *column);
+
+-const char *drizzle_column_type_str(drizzle_column_type_t type);
++const char *drizzle_column_type_str(const drizzle_column_type_t type);
+
+-drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column);
++drizzle_column_flags_t drizzle_column_flags(const drizzle_column_st *column);
+
+-uint8_t drizzle_column_decimals(drizzle_column_st *column);
++uint8_t drizzle_column_decimals(const drizzle_column_st *column);
+
+-const unsigned char *drizzle_column_default_value(drizzle_column_st *column, size_t *size
++const unsigned char *drizzle_column_default_value(const drizzle_column_st *column, size_t *size);
+
+```
+- `include/libdrizzle-redux/column_client.h`
+
+```diff
+
+-drizzle_column_st *drizzle_column_index(drizzle_result_st *result, uint16_t column);
++drizzle_column_st *drizzle_column_index(const drizzle_result_st *result, uint16_t column);
+
+-uint16_t drizzle_column_current(drizzle_result_st *result);
++uint16_t drizzle_column_current(const drizzle_result_st *result);
+```
+
+- `include/libdrizzle-redux/conn.h`
+
+```diff
+-int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option);
++int drizzle_socket_get_option(const drizzle_st *con, drizzle_socket_option_t option);
+
+-bool drizzle_options_get_non_blocking(drizzle_options_st *options);
++bool drizzle_options_get_non_blocking(const drizzle_options_st *options);
+
+-bool drizzle_options_get_raw_scramble(drizzle_options_st *options);
++bool drizzle_options_get_raw_scramble(const drizzle_options_st *options);
+
+-bool drizzle_options_get_found_rows(drizzle_options_st *options);
++bool drizzle_options_get_found_rows(const drizzle_options_st *options);
+
+-bool drizzle_options_get_interactive(drizzle_options_st *options);
++bool drizzle_options_get_interactive(const drizzle_options_st *options);
+
+-bool drizzle_options_get_multi_statements(drizzle_options_st *options);
++bool drizzle_options_get_multi_statements(const drizzle_options_st *options);
+
+-bool drizzle_options_get_auth_plugin(drizzle_options_st *options);
++bool drizzle_options_get_auth_plugin(const drizzle_options_st *options);
+
+-drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options);
++drizzle_socket_owner_t drizzle_options_get_socket_owner(const drizzle_options_st *options);
+
+```
+
+- `include/libdrizzle-redux/drizzle.h`
+
+```diff
+-const char *drizzle_verbose_name(drizzle_verbose_t verbose);
++const char *drizzle_verbose_name(const drizzle_verbose_t verbose);
+```
+
+- `include/libdrizzle-redux/query.h`
+```diff
+
+-ssize_t drizzle_escape_string(drizzle_st *con, char **to, const char *from, const size_t from_size);
++ssize_t drizzle_escape_string(const drizzle_st *con, char **to, const char *from, const size_t from_size);
+
+-ssize_t drizzle_escape_str(drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern);
++ssize_t drizzle_escape_str(const drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern);
+```
+
+- `include/libdrizzle-redux/result.h`
+
+```diff
+-bool drizzle_result_eof(drizzle_result_st *result);
++bool drizzle_result_eof(const drizzle_result_st *result);
+
+-const char *drizzle_result_message(drizzle_result_st *result);
++const char *drizzle_result_message(const drizzle_result_st *result);
+
+-uint16_t drizzle_result_error_code(drizzle_result_st *result);
++uint16_t drizzle_result_error_code(const drizzle_result_st *result);
+
+-const char *drizzle_result_sqlstate(drizzle_result_st *result);
++const char *drizzle_result_sqlstate(const drizzle_result_st *result);
+
+-uint16_t drizzle_result_warning_count(drizzle_result_st *result);
++uint16_t drizzle_result_warning_count(const drizzle_result_st *result);
+
+-uint64_t drizzle_result_insert_id(drizzle_result_st *result);
++uint64_t drizzle_result_insert_id(const drizzle_result_st *result);
+
+-uint64_t drizzle_result_affected_rows(drizzle_result_st *result);
++uint64_t drizzle_result_affected_rows(const drizzle_result_st *result);
+
+-uint16_t drizzle_result_column_count(drizzle_result_st *result);
++uint16_t drizzle_result_column_count(const drizzle_result_st *result);
+
+-uint64_t drizzle_result_row_count(drizzle_result_st *result);
++uint64_t drizzle_result_row_count(const drizzle_result_st *result);
+```
+
+- `include/libdrizzle-redux/result_client.h`
+
+```diff
+-size_t drizzle_result_row_size(drizzle_result_st *result);
++size_t drizzle_result_row_size(const drizzle_result_st *result);
+```
+
+- `include/libdrizzle-redux/return.h`
+
+```diff
+-static inline bool drizzle_success(drizzle_return_t ret)
++static inline bool drizzle_success(const drizzle_return_t ret)
+ {
+-static inline bool drizzle_failed(drizzle_return_t ret)
++static inline bool drizzle_failed(const drizzle_return_t ret)
+ {
+```
+
+- `include/libdrizzle-redux/row_client.h`
+
+```diff
+-size_t *drizzle_row_field_sizes(drizzle_result_st *result);
++size_t *drizzle_row_field_sizes(const drizzle_result_st *result);
+
+-drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row);
++drizzle_row_t drizzle_row_index(const drizzle_result_st *result, uint64_t row);
+
+-uint64_t drizzle_row_current(drizzle_result_st *result);
++uint64_t drizzle_row_current(const drizzle_result_st *result);
+```
+
+- `include/libdrizzle-redux/statement.h`
+
+```diff
+-uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt);
++uint16_t drizzle_stmt_column_count(const drizzle_stmt_st *stmt);
+
+-uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt);
++uint64_t drizzle_stmt_affected_rows(const drizzle_stmt_st *stmt);
+
+-uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt);
++uint64_t drizzle_stmt_insert_id(const drizzle_stmt_st *stmt);
+
+-uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt);
++uint16_t drizzle_stmt_param_count(const drizzle_stmt_st *stmt);
+
+-uint64_t drizzle_stmt_row_count(drizzle_stmt_st *stmt);
++uint64_t drizzle_stmt_row_count(const drizzle_stmt_st *stmt);
+
+-bool drizzle_stmt_get_is_null_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
++bool drizzle_stmt_get_is_null_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+
+-bool drizzle_stmt_get_is_null(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
++bool drizzle_stmt_get_is_null(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
+
+-bool drizzle_stmt_get_is_unsigned_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
++bool drizzle_stmt_get_is_unsigned_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+
+-bool drizzle_stmt_get_is_unsigned(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
++bool drizzle_stmt_get_is_unsigned(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
+
+-const char *drizzle_stmt_get_string_from_name(drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
++const char *drizzle_stmt_get_string_from_name(const drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
+
+-const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr)
++const char *drizzle_stmt_get_string(const drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr);
+
+-uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
++uint32_t drizzle_stmt_get_int(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
+
+-uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
++uint32_t drizzle_stmt_get_int_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
+
+-uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name,drizzle_return_t *ret_ptr);
++uint64_t drizzle_stmt_get_bigint_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
+
+-uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
++uint64_t drizzle_stmt_get_bigint(const drizzle_stmt_st *stmt, uint16_t column_number,drizzle_return_t *ret_ptr);
+
+-double drizzle_stmt_get_double(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
++double drizzle_stmt_get_double(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
+
+-double drizzle_stmt_get_double_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
++double drizzle_stmt_get_double_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
+```
+
+### Add const qualifier to binlog callback function signature
+
+- `include/libdrizzle-redux/constants.h`
+
+```diff
+-typedef void (drizzle_binlog_fn)(drizzle_binlog_event_st *event, void *context);
++typedef void (drizzle_binlog_fn)(const drizzle_binlog_event_st *event, void *context);
+```

--- a/relnotes/const-qualifier.feature.md
+++ b/relnotes/const-qualifier.feature.md
@@ -4,38 +4,38 @@
 
 ```diff
 
--uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event);
-+uint32_t drizzle_binlog_event_timestamp(const drizzle_binlog_event_st *event);
+-uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event)
++uint32_t drizzle_binlog_event_timestamp(const drizzle_binlog_event_st *event)
 
--drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *event);
-+drizzle_binlog_event_types_t drizzle_binlog_event_type(const drizzle_binlog_event_st *event);
+-drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *event)
++drizzle_binlog_event_types_t drizzle_binlog_event_type(const drizzle_binlog_event_st *event)
 
--uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event);
-+uint32_t drizzle_binlog_event_server_id(const drizzle_binlog_event_st *event);
+-uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event)
++uint32_t drizzle_binlog_event_server_id(const drizzle_binlog_event_st *event)
 
--uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event);
-+uint32_t drizzle_binlog_event_length(const drizzle_binlog_event_st *event);
+-uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event)
++uint32_t drizzle_binlog_event_length(const drizzle_binlog_event_st *event)
 
--uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event);
-+uint32_t drizzle_binlog_event_next_pos(const drizzle_binlog_event_st *event);
+-uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event)
++uint32_t drizzle_binlog_event_next_pos(const drizzle_binlog_event_st *event)
 
--uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event);
-+uint16_t drizzle_binlog_event_flags(const drizzle_binlog_event_st *event);
+-uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event)
++uint16_t drizzle_binlog_event_flags(const drizzle_binlog_event_st *event)
 
--uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event);
-+uint16_t drizzle_binlog_event_extra_flags(const drizzle_binlog_event_st *event);
+-uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event)
++uint16_t drizzle_binlog_event_extra_flags(const drizzle_binlog_event_st *event)
 
--const unsigned char *drizzle_binlog_event_data(drizzle_binlog_event_st *event);
-+const unsigned char *drizzle_binlog_event_data(const drizzle_binlog_event_st *event);
+-const unsigned char *drizzle_binlog_event_data(drizzle_binlog_event_st *event)
++const unsigned char *drizzle_binlog_event_data(const drizzle_binlog_event_st *event)
 
--const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *event);
-+const unsigned char *drizzle_binlog_event_raw_data(const drizzle_binlog_event_st *event);
+-const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *event)
++const unsigned char *drizzle_binlog_event_raw_data(const drizzle_binlog_event_st *event)
 
--uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event);
-+uint32_t drizzle_binlog_event_raw_length(const drizzle_binlog_event_st *event);
+-uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event)
++uint32_t drizzle_binlog_event_raw_length(const drizzle_binlog_event_st *event)
 
--const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type);
-+const char *drizzle_binlog_event_type_str(const drizzle_binlog_event_types_t event_type);
+-const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type)
++const char *drizzle_binlog_event_type_str(const drizzle_binlog_event_types_t event_type)
 
 ```
 
@@ -43,142 +43,142 @@
 
 ```diff
 
--const char *drizzle_column_catalog(drizzle_column_st *column);
-+const char *drizzle_column_catalog(const drizzle_column_st *column);
+-const char *drizzle_column_catalog(drizzle_column_st *column)
++const char *drizzle_column_catalog(const drizzle_column_st *column)
 
--const char *drizzle_column_db(drizzle_column_st *column);
-+const char *drizzle_column_db(const drizzle_column_st *column);
+-const char *drizzle_column_db(drizzle_column_st *column)
++const char *drizzle_column_db(const drizzle_column_st *column)
 
--const char *drizzle_column_table(drizzle_column_st *column);
-+const char *drizzle_column_table(const drizzle_column_st *column);
+-const char *drizzle_column_table(drizzle_column_st *column)
++const char *drizzle_column_table(const drizzle_column_st *column)
 
--const char *drizzle_column_orig_table(drizzle_column_st *column);
-+const char *drizzle_column_orig_table(const drizzle_column_st *column);
+-const char *drizzle_column_orig_table(drizzle_column_st *column)
++const char *drizzle_column_orig_table(const drizzle_column_st *column)
 
--const char *drizzle_column_name(drizzle_column_st *column);
-+const char *drizzle_column_name(const drizzle_column_st *column);
+-const char *drizzle_column_name(drizzle_column_st *column)
++const char *drizzle_column_name(const drizzle_column_st *column)
 
--const char *drizzle_column_orig_name(drizzle_column_st *column);
-+const char *drizzle_column_orig_name(const drizzle_column_st *column);
+-const char *drizzle_column_orig_name(drizzle_column_st *column)
++const char *drizzle_column_orig_name(const drizzle_column_st *column)
 
--drizzle_charset_t drizzle_column_charset(drizzle_column_st *column);
-+drizzle_charset_t drizzle_column_charset(const drizzle_column_st *column);
+-drizzle_charset_t drizzle_column_charset(drizzle_column_st *column)
++drizzle_charset_t drizzle_column_charset(const drizzle_column_st *column)
 
--uint32_t drizzle_column_size(drizzle_column_st *column);
-+uint32_t drizzle_column_size(const drizzle_column_st *column);
+-uint32_t drizzle_column_size(drizzle_column_st *column)
++uint32_t drizzle_column_size(const drizzle_column_st *column)
 
--size_t drizzle_column_max_size(drizzle_column_st *column);
-+size_t drizzle_column_max_size(const drizzle_column_st *column);
+-size_t drizzle_column_max_size(drizzle_column_st *column)
++size_t drizzle_column_max_size(const drizzle_column_st *column)
 
--drizzle_column_type_t drizzle_column_type(drizzle_column_st *column);
-+drizzle_column_type_t drizzle_column_type(const drizzle_column_st *column);
+-drizzle_column_type_t drizzle_column_type(drizzle_column_st *column)
++drizzle_column_type_t drizzle_column_type(const drizzle_column_st *column)
 
--const char *drizzle_column_type_str(drizzle_column_type_t type);
-+const char *drizzle_column_type_str(const drizzle_column_type_t type);
+-const char *drizzle_column_type_str(drizzle_column_type_t type)
++const char *drizzle_column_type_str(const drizzle_column_type_t type)
 
--drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column);
-+drizzle_column_flags_t drizzle_column_flags(const drizzle_column_st *column);
+-drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column)
++drizzle_column_flags_t drizzle_column_flags(const drizzle_column_st *column)
 
--uint8_t drizzle_column_decimals(drizzle_column_st *column);
-+uint8_t drizzle_column_decimals(const drizzle_column_st *column);
+-uint8_t drizzle_column_decimals(drizzle_column_st *column)
++uint8_t drizzle_column_decimals(const drizzle_column_st *column)
 
 -const unsigned char *drizzle_column_default_value(drizzle_column_st *column, size_t *size
-+const unsigned char *drizzle_column_default_value(const drizzle_column_st *column, size_t *size);
++const unsigned char *drizzle_column_default_value(const drizzle_column_st *column, size_t *size)
 
 ```
 - `include/libdrizzle-redux/column_client.h`
 
 ```diff
 
--drizzle_column_st *drizzle_column_index(drizzle_result_st *result, uint16_t column);
-+drizzle_column_st *drizzle_column_index(const drizzle_result_st *result, uint16_t column);
+-drizzle_column_st *drizzle_column_index(drizzle_result_st *result, uint16_t column)
++drizzle_column_st *drizzle_column_index(const drizzle_result_st *result, uint16_t column)
 
--uint16_t drizzle_column_current(drizzle_result_st *result);
-+uint16_t drizzle_column_current(const drizzle_result_st *result);
+-uint16_t drizzle_column_current(drizzle_result_st *result)
++uint16_t drizzle_column_current(const drizzle_result_st *result)
 ```
 
 - `include/libdrizzle-redux/conn.h`
 
 ```diff
--int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option);
-+int drizzle_socket_get_option(const drizzle_st *con, drizzle_socket_option_t option);
+-int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option)
++int drizzle_socket_get_option(const drizzle_st *con, drizzle_socket_option_t option)
 
--bool drizzle_options_get_non_blocking(drizzle_options_st *options);
-+bool drizzle_options_get_non_blocking(const drizzle_options_st *options);
+-bool drizzle_options_get_non_blocking(drizzle_options_st *options)
++bool drizzle_options_get_non_blocking(const drizzle_options_st *options)
 
--bool drizzle_options_get_raw_scramble(drizzle_options_st *options);
-+bool drizzle_options_get_raw_scramble(const drizzle_options_st *options);
+-bool drizzle_options_get_raw_scramble(drizzle_options_st *options)
++bool drizzle_options_get_raw_scramble(const drizzle_options_st *options)
 
--bool drizzle_options_get_found_rows(drizzle_options_st *options);
-+bool drizzle_options_get_found_rows(const drizzle_options_st *options);
+-bool drizzle_options_get_found_rows(drizzle_options_st *options)
++bool drizzle_options_get_found_rows(const drizzle_options_st *options)
 
--bool drizzle_options_get_interactive(drizzle_options_st *options);
-+bool drizzle_options_get_interactive(const drizzle_options_st *options);
+-bool drizzle_options_get_interactive(drizzle_options_st *options)
++bool drizzle_options_get_interactive(const drizzle_options_st *options)
 
--bool drizzle_options_get_multi_statements(drizzle_options_st *options);
-+bool drizzle_options_get_multi_statements(const drizzle_options_st *options);
+-bool drizzle_options_get_multi_statements(drizzle_options_st *options)
++bool drizzle_options_get_multi_statements(const drizzle_options_st *options)
 
--bool drizzle_options_get_auth_plugin(drizzle_options_st *options);
-+bool drizzle_options_get_auth_plugin(const drizzle_options_st *options);
+-bool drizzle_options_get_auth_plugin(drizzle_options_st *options)
++bool drizzle_options_get_auth_plugin(const drizzle_options_st *options)
 
--drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options);
-+drizzle_socket_owner_t drizzle_options_get_socket_owner(const drizzle_options_st *options);
+-drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options)
++drizzle_socket_owner_t drizzle_options_get_socket_owner(const drizzle_options_st *options)
 
 ```
 
 - `include/libdrizzle-redux/drizzle.h`
 
 ```diff
--const char *drizzle_verbose_name(drizzle_verbose_t verbose);
-+const char *drizzle_verbose_name(const drizzle_verbose_t verbose);
+-const char *drizzle_verbose_name(drizzle_verbose_t verbose)
++const char *drizzle_verbose_name(const drizzle_verbose_t verbose)
 ```
 
 - `include/libdrizzle-redux/query.h`
 ```diff
 
--ssize_t drizzle_escape_string(drizzle_st *con, char **to, const char *from, const size_t from_size);
-+ssize_t drizzle_escape_string(const drizzle_st *con, char **to, const char *from, const size_t from_size);
+-ssize_t drizzle_escape_string(drizzle_st *con, char **to, const char *from, const size_t from_size)
++ssize_t drizzle_escape_string(const drizzle_st *con, char **to, const char *from, const size_t from_size)
 
--ssize_t drizzle_escape_str(drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern);
-+ssize_t drizzle_escape_str(const drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern);
+-ssize_t drizzle_escape_str(drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern)
++ssize_t drizzle_escape_str(const drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern)
 ```
 
 - `include/libdrizzle-redux/result.h`
 
 ```diff
--bool drizzle_result_eof(drizzle_result_st *result);
-+bool drizzle_result_eof(const drizzle_result_st *result);
+-bool drizzle_result_eof(drizzle_result_st *result)
++bool drizzle_result_eof(const drizzle_result_st *result)
 
--const char *drizzle_result_message(drizzle_result_st *result);
-+const char *drizzle_result_message(const drizzle_result_st *result);
+-const char *drizzle_result_message(drizzle_result_st *result)
++const char *drizzle_result_message(const drizzle_result_st *result)
 
--uint16_t drizzle_result_error_code(drizzle_result_st *result);
-+uint16_t drizzle_result_error_code(const drizzle_result_st *result);
+-uint16_t drizzle_result_error_code(drizzle_result_st *result)
++uint16_t drizzle_result_error_code(const drizzle_result_st *result)
 
--const char *drizzle_result_sqlstate(drizzle_result_st *result);
-+const char *drizzle_result_sqlstate(const drizzle_result_st *result);
+-const char *drizzle_result_sqlstate(drizzle_result_st *result)
++const char *drizzle_result_sqlstate(const drizzle_result_st *result)
 
--uint16_t drizzle_result_warning_count(drizzle_result_st *result);
-+uint16_t drizzle_result_warning_count(const drizzle_result_st *result);
+-uint16_t drizzle_result_warning_count(drizzle_result_st *result)
++uint16_t drizzle_result_warning_count(const drizzle_result_st *result)
 
--uint64_t drizzle_result_insert_id(drizzle_result_st *result);
-+uint64_t drizzle_result_insert_id(const drizzle_result_st *result);
+-uint64_t drizzle_result_insert_id(drizzle_result_st *result)
++uint64_t drizzle_result_insert_id(const drizzle_result_st *result)
 
--uint64_t drizzle_result_affected_rows(drizzle_result_st *result);
-+uint64_t drizzle_result_affected_rows(const drizzle_result_st *result);
+-uint64_t drizzle_result_affected_rows(drizzle_result_st *result)
++uint64_t drizzle_result_affected_rows(const drizzle_result_st *result)
 
--uint16_t drizzle_result_column_count(drizzle_result_st *result);
-+uint16_t drizzle_result_column_count(const drizzle_result_st *result);
+-uint16_t drizzle_result_column_count(drizzle_result_st *result)
++uint16_t drizzle_result_column_count(const drizzle_result_st *result)
 
--uint64_t drizzle_result_row_count(drizzle_result_st *result);
-+uint64_t drizzle_result_row_count(const drizzle_result_st *result);
+-uint64_t drizzle_result_row_count(drizzle_result_st *result)
++uint64_t drizzle_result_row_count(const drizzle_result_st *result)
 ```
 
 - `include/libdrizzle-redux/result_client.h`
 
 ```diff
--size_t drizzle_result_row_size(drizzle_result_st *result);
-+size_t drizzle_result_row_size(const drizzle_result_st *result);
+-size_t drizzle_result_row_size(drizzle_result_st *result)
++size_t drizzle_result_row_size(const drizzle_result_st *result)
 ```
 
 - `include/libdrizzle-redux/return.h`
@@ -195,69 +195,69 @@
 - `include/libdrizzle-redux/row_client.h`
 
 ```diff
--size_t *drizzle_row_field_sizes(drizzle_result_st *result);
-+size_t *drizzle_row_field_sizes(const drizzle_result_st *result);
+-size_t *drizzle_row_field_sizes(drizzle_result_st *result)
++size_t *drizzle_row_field_sizes(const drizzle_result_st *result)
 
--drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row);
-+drizzle_row_t drizzle_row_index(const drizzle_result_st *result, uint64_t row);
+-drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row)
++drizzle_row_t drizzle_row_index(const drizzle_result_st *result, uint64_t row)
 
--uint64_t drizzle_row_current(drizzle_result_st *result);
-+uint64_t drizzle_row_current(const drizzle_result_st *result);
+-uint64_t drizzle_row_current(drizzle_result_st *result)
++uint64_t drizzle_row_current(const drizzle_result_st *result)
 ```
 
 - `include/libdrizzle-redux/statement.h`
 
 ```diff
--uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt);
-+uint16_t drizzle_stmt_column_count(const drizzle_stmt_st *stmt);
+-uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt)
++uint16_t drizzle_stmt_column_count(const drizzle_stmt_st *stmt)
 
--uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt);
-+uint64_t drizzle_stmt_affected_rows(const drizzle_stmt_st *stmt);
+-uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt)
++uint64_t drizzle_stmt_affected_rows(const drizzle_stmt_st *stmt)
 
--uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt);
-+uint64_t drizzle_stmt_insert_id(const drizzle_stmt_st *stmt);
+-uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt)
++uint64_t drizzle_stmt_insert_id(const drizzle_stmt_st *stmt)
 
--uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt);
-+uint16_t drizzle_stmt_param_count(const drizzle_stmt_st *stmt);
+-uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt)
++uint16_t drizzle_stmt_param_count(const drizzle_stmt_st *stmt)
 
--uint64_t drizzle_stmt_row_count(drizzle_stmt_st *stmt);
-+uint64_t drizzle_stmt_row_count(const drizzle_stmt_st *stmt);
+-uint64_t drizzle_stmt_row_count(drizzle_stmt_st *stmt)
++uint64_t drizzle_stmt_row_count(const drizzle_stmt_st *stmt)
 
 -bool drizzle_stmt_get_is_null_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 +bool drizzle_stmt_get_is_null_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
 -bool drizzle_stmt_get_is_null(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
-+bool drizzle_stmt_get_is_null(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
++bool drizzle_stmt_get_is_null(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
 -bool drizzle_stmt_get_is_unsigned_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 +bool drizzle_stmt_get_is_unsigned_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
 -bool drizzle_stmt_get_is_unsigned(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
-+bool drizzle_stmt_get_is_unsigned(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
++bool drizzle_stmt_get_is_unsigned(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
 -const char *drizzle_stmt_get_string_from_name(drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
 +const char *drizzle_stmt_get_string_from_name(const drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
 
 -const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr)
-+const char *drizzle_stmt_get_string(const drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr);
++const char *drizzle_stmt_get_string(const drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr)
 
--uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
-+uint32_t drizzle_stmt_get_int(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
+-uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
++uint32_t drizzle_stmt_get_int(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
 -uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
-+uint32_t drizzle_stmt_get_int_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
++uint32_t drizzle_stmt_get_int_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
--uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name,drizzle_return_t *ret_ptr);
-+uint64_t drizzle_stmt_get_bigint_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
+-uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name,drizzle_return_t *ret_ptr)
++uint64_t drizzle_stmt_get_bigint_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 
 -uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
-+uint64_t drizzle_stmt_get_bigint(const drizzle_stmt_st *stmt, uint16_t column_number,drizzle_return_t *ret_ptr);
++uint64_t drizzle_stmt_get_bigint(const drizzle_stmt_st *stmt, uint16_t column_number,drizzle_return_t *ret_ptr)
 
 -double drizzle_stmt_get_double(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
-+double drizzle_stmt_get_double(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr);
++double drizzle_stmt_get_double(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 
--double drizzle_stmt_get_double_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
-+double drizzle_stmt_get_double_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr);
+-double drizzle_stmt_get_double_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
++double drizzle_stmt_get_double_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 ```
 
 ### Add const qualifier to binlog callback function signature
@@ -265,6 +265,6 @@
 - `include/libdrizzle-redux/constants.h`
 
 ```diff
--typedef void (drizzle_binlog_fn)(drizzle_binlog_event_st *event, void *context);
-+typedef void (drizzle_binlog_fn)(const drizzle_binlog_event_st *event, void *context);
+-typedef void (drizzle_binlog_fn)(drizzle_binlog_event_st *event, void *context)
++typedef void (drizzle_binlog_fn)(const drizzle_binlog_event_st *event, void *context)
 ```

--- a/src/binlog.cc
+++ b/src/binlog.cc
@@ -183,7 +183,7 @@ drizzle_return_t drizzle_binlog_start(drizzle_binlog_st *binlog,
   return drizzle_state_loop(con);
 }
 
-uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event)
+uint32_t drizzle_binlog_event_timestamp(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -193,7 +193,7 @@ uint32_t drizzle_binlog_event_timestamp(drizzle_binlog_event_st *event)
   return event->timestamp;
 }
 
-drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *event)
+drizzle_binlog_event_types_t drizzle_binlog_event_type(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -203,7 +203,7 @@ drizzle_binlog_event_types_t drizzle_binlog_event_type(drizzle_binlog_event_st *
   return event->type;
 }
 
-uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event)
+uint32_t drizzle_binlog_event_server_id(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -213,7 +213,7 @@ uint32_t drizzle_binlog_event_server_id(drizzle_binlog_event_st *event)
   return event->server_id;
 }
 
-uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event)
+uint32_t drizzle_binlog_event_length(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -223,7 +223,7 @@ uint32_t drizzle_binlog_event_length(drizzle_binlog_event_st *event)
   return event->length;
 }
 
-uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event)
+uint32_t drizzle_binlog_event_next_pos(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -233,7 +233,7 @@ uint32_t drizzle_binlog_event_next_pos(drizzle_binlog_event_st *event)
   return event->next_pos;
 }
 
-uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event)
+uint16_t drizzle_binlog_event_flags(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -243,7 +243,7 @@ uint16_t drizzle_binlog_event_flags(drizzle_binlog_event_st *event)
   return event->flags;
 }
 
-uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event)
+uint16_t drizzle_binlog_event_extra_flags(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -253,7 +253,7 @@ uint16_t drizzle_binlog_event_extra_flags(drizzle_binlog_event_st *event)
   return event->extra_flags;
 }
 
-const unsigned char *drizzle_binlog_event_data(drizzle_binlog_event_st *event)
+const unsigned char *drizzle_binlog_event_data(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -263,7 +263,7 @@ const unsigned char *drizzle_binlog_event_data(drizzle_binlog_event_st *event)
   return event->data;
 }
 
-const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *event)
+const unsigned char *drizzle_binlog_event_raw_data(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -273,7 +273,7 @@ const unsigned char *drizzle_binlog_event_raw_data(drizzle_binlog_event_st *even
   return event->raw_data;
 }
 
-uint32_t drizzle_binlog_event_raw_length(drizzle_binlog_event_st *event)
+uint32_t drizzle_binlog_event_raw_length(const drizzle_binlog_event_st *event)
 {
   if (event == NULL)
   {
@@ -443,7 +443,7 @@ drizzle_return_t drizzle_state_binlog_read(drizzle_st *con)
   return DRIZZLE_RETURN_OK;
 }
 
-const char *drizzle_binlog_event_type_str(drizzle_binlog_event_types_t event_type)
+const char *drizzle_binlog_event_type_str(const drizzle_binlog_event_types_t event_type)
 {
     switch(event_type)
     {

--- a/src/column.cc
+++ b/src/column.cc
@@ -94,7 +94,7 @@ void drizzle_column_free(drizzle_column_st *column)
   delete column;
 }
 
-drizzle_result_st *drizzle_column_drizzle_result(drizzle_column_st *column)
+drizzle_result_st *drizzle_column_drizzle_result(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -104,7 +104,7 @@ drizzle_result_st *drizzle_column_drizzle_result(drizzle_column_st *column)
   return column->result;
 }
 
-const char *drizzle_column_catalog(drizzle_column_st *column)
+const char *drizzle_column_catalog(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -114,7 +114,7 @@ const char *drizzle_column_catalog(drizzle_column_st *column)
   return column->catalog;
 }
 
-const char *drizzle_column_db(drizzle_column_st *column)
+const char *drizzle_column_db(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -124,7 +124,7 @@ const char *drizzle_column_db(drizzle_column_st *column)
   return column->db;
 }
 
-const char *drizzle_column_table(drizzle_column_st *column)
+const char *drizzle_column_table(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -134,7 +134,7 @@ const char *drizzle_column_table(drizzle_column_st *column)
   return column->table;
 }
 
-const char *drizzle_column_orig_table(drizzle_column_st *column)
+const char *drizzle_column_orig_table(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -144,7 +144,7 @@ const char *drizzle_column_orig_table(drizzle_column_st *column)
   return column->orig_table;
 }
 
-const char *drizzle_column_name(drizzle_column_st *column)
+const char *drizzle_column_name(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -154,7 +154,7 @@ const char *drizzle_column_name(drizzle_column_st *column)
   return column->name;
 }
 
-const char *drizzle_column_orig_name(drizzle_column_st *column)
+const char *drizzle_column_orig_name(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -164,7 +164,7 @@ const char *drizzle_column_orig_name(drizzle_column_st *column)
   return column->orig_name;
 }
 
-drizzle_charset_t drizzle_column_charset(drizzle_column_st *column)
+drizzle_charset_t drizzle_column_charset(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -174,7 +174,7 @@ drizzle_charset_t drizzle_column_charset(drizzle_column_st *column)
   return column->charset;
 }
 
-uint32_t drizzle_column_size(drizzle_column_st *column)
+uint32_t drizzle_column_size(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -184,7 +184,7 @@ uint32_t drizzle_column_size(drizzle_column_st *column)
   return column->size;
 }
 
-size_t drizzle_column_max_size(drizzle_column_st *column)
+size_t drizzle_column_max_size(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -194,7 +194,7 @@ size_t drizzle_column_max_size(drizzle_column_st *column)
   return column->max_size;
 }
 
-drizzle_column_type_t drizzle_column_type(drizzle_column_st *column)
+drizzle_column_type_t drizzle_column_type(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -204,7 +204,7 @@ drizzle_column_type_t drizzle_column_type(drizzle_column_st *column)
   return column->type;
 }
 
-const char *drizzle_column_type_str(drizzle_column_type_t type)
+const char *drizzle_column_type_str(const drizzle_column_type_t type)
 {
     switch (type)
     {
@@ -274,7 +274,7 @@ const char *drizzle_column_type_str(drizzle_column_type_t type)
     return "UNKNOWN";
 }
 
-drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column)
+drizzle_column_flags_t drizzle_column_flags(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -284,7 +284,7 @@ drizzle_column_flags_t drizzle_column_flags(drizzle_column_st *column)
   return drizzle_column_flags_t(column->flags);
 }
 
-uint8_t drizzle_column_decimals(drizzle_column_st *column)
+uint8_t drizzle_column_decimals(const drizzle_column_st *column)
 {
   if (column == NULL)
   {
@@ -294,7 +294,7 @@ uint8_t drizzle_column_decimals(drizzle_column_st *column)
   return column->decimals;
 }
 
-const unsigned char *drizzle_column_default_value(drizzle_column_st *column,
+const unsigned char *drizzle_column_default_value(const drizzle_column_st *column,
                                             size_t *size)
 {
   if (column == NULL)
@@ -463,7 +463,7 @@ void drizzle_column_seek(drizzle_result_st *result, uint16_t column)
   }
 }
 
-drizzle_column_st *drizzle_column_index(drizzle_result_st *result,
+drizzle_column_st *drizzle_column_index(const drizzle_result_st *result,
                                         uint16_t column)
 {
   if (result == NULL)
@@ -479,7 +479,7 @@ drizzle_column_st *drizzle_column_index(drizzle_result_st *result,
   return &(result->column_buffer[column]);
 }
 
-uint16_t drizzle_column_current(drizzle_result_st *result)
+uint16_t drizzle_column_current(const drizzle_result_st *result)
 {
   if (result == NULL)
   {

--- a/src/conn.cc
+++ b/src/conn.cc
@@ -265,7 +265,7 @@ void drizzle_socket_set_option(drizzle_st *con, drizzle_socket_option_t option,
   }
 }
 
-int drizzle_socket_get_option(drizzle_st *con, drizzle_socket_option_t option)
+int drizzle_socket_get_option(const drizzle_st *con, drizzle_socket_option_t option)
 {
   if (con == NULL)
   {
@@ -300,7 +300,7 @@ void drizzle_options_set_non_blocking(drizzle_options_st *options, bool state)
   options->non_blocking= state;
 }
 
-bool drizzle_options_get_non_blocking(drizzle_options_st *options)
+bool drizzle_options_get_non_blocking(const drizzle_options_st *options)
 {
   if (options == NULL)
   {
@@ -318,7 +318,7 @@ void drizzle_options_set_raw_scramble(drizzle_options_st *options, bool state)
   options->raw_scramble= state;
 }
 
-bool drizzle_options_get_raw_scramble(drizzle_options_st *options)
+bool drizzle_options_get_raw_scramble(const drizzle_options_st *options)
 {
   if (options == NULL)
   {
@@ -336,7 +336,7 @@ void drizzle_options_set_found_rows(drizzle_options_st *options, bool state)
   options->found_rows= state;
 }
 
-bool drizzle_options_get_found_rows(drizzle_options_st *options)
+bool drizzle_options_get_found_rows(const drizzle_options_st *options)
 {
   if (options == NULL)
   {
@@ -354,7 +354,7 @@ void drizzle_options_set_interactive(drizzle_options_st *options, bool state)
   options->interactive= state;
 }
 
-bool drizzle_options_get_interactive(drizzle_options_st *options)
+bool drizzle_options_get_interactive(const drizzle_options_st *options)
 {
   if (options == NULL)
   {
@@ -372,7 +372,7 @@ void drizzle_options_set_multi_statements(drizzle_options_st *options, bool stat
   options->multi_statements= state;
 }
 
-bool drizzle_options_get_multi_statements(drizzle_options_st *options)
+bool drizzle_options_get_multi_statements(const drizzle_options_st *options)
 {
   if (options == NULL)
   {
@@ -390,7 +390,7 @@ void drizzle_options_set_auth_plugin(drizzle_options_st *options, bool state)
   options->auth_plugin= state;
 }
 
-bool drizzle_options_get_auth_plugin(drizzle_options_st *options)
+bool drizzle_options_get_auth_plugin(const drizzle_options_st *options)
 {
   if (options == NULL)
   {
@@ -409,7 +409,7 @@ void drizzle_options_set_socket_owner(drizzle_options_st *options,
   options->socket_owner = owner;
 }
 
-drizzle_socket_owner_t drizzle_options_get_socket_owner(drizzle_options_st *options)
+drizzle_socket_owner_t drizzle_options_get_socket_owner(const drizzle_options_st *options)
 {
   if (options == NULL)
   {

--- a/src/query.cc
+++ b/src/query.cc
@@ -57,7 +57,7 @@ drizzle_result_st *drizzle_query(drizzle_st *con,
                                    (unsigned char *)query, size, size, ret_ptr);
 }
 
-ssize_t drizzle_escape_str(drizzle_st *con, char **destination, const char *from, const size_t from_size, bool is_pattern)
+ssize_t drizzle_escape_str(const drizzle_st *con, char **destination, const char *from, const size_t from_size, bool is_pattern)
 {
   (void)con;
   const char *end;
@@ -160,7 +160,7 @@ ssize_t drizzle_escape_str(drizzle_st *con, char **destination, const char *from
   return to_size;
 }
 
-ssize_t drizzle_escape_string(drizzle_st *con, char **destination, const char *from, const size_t from_size)
+ssize_t drizzle_escape_string(const drizzle_st *con, char **destination, const char *from, const size_t from_size)
 {
     return drizzle_escape_str(con, destination, from, from_size, false);
 }

--- a/src/result.cc
+++ b/src/result.cc
@@ -170,7 +170,7 @@ drizzle_st *drizzle_result_drizzle_con(drizzle_result_st *result)
   return result->con;
 }
 
-bool drizzle_result_eof(drizzle_result_st *result)
+bool drizzle_result_eof(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -180,7 +180,7 @@ bool drizzle_result_eof(drizzle_result_st *result)
   return result->options & DRIZZLE_RESULT_EOF_PACKET;
 }
 
-const char *drizzle_result_message(drizzle_result_st *result)
+const char *drizzle_result_message(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -190,7 +190,7 @@ const char *drizzle_result_message(drizzle_result_st *result)
   return result->info;
 }
 
-uint16_t drizzle_result_error_code(drizzle_result_st *result)
+uint16_t drizzle_result_error_code(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -200,7 +200,7 @@ uint16_t drizzle_result_error_code(drizzle_result_st *result)
   return result->error_code;
 }
 
-const char *drizzle_result_sqlstate(drizzle_result_st *result)
+const char *drizzle_result_sqlstate(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -210,7 +210,7 @@ const char *drizzle_result_sqlstate(drizzle_result_st *result)
   return result->sqlstate;
 }
 
-uint16_t drizzle_result_warning_count(drizzle_result_st *result)
+uint16_t drizzle_result_warning_count(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -220,7 +220,7 @@ uint16_t drizzle_result_warning_count(drizzle_result_st *result)
   return result->warning_count;
 }
 
-uint64_t drizzle_result_insert_id(drizzle_result_st *result)
+uint64_t drizzle_result_insert_id(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -230,7 +230,7 @@ uint64_t drizzle_result_insert_id(drizzle_result_st *result)
   return result->insert_id;
 }
 
-uint64_t drizzle_result_affected_rows(drizzle_result_st *result)
+uint64_t drizzle_result_affected_rows(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -240,7 +240,7 @@ uint64_t drizzle_result_affected_rows(drizzle_result_st *result)
   return result->affected_rows;
 }
 
-uint16_t drizzle_result_column_count(drizzle_result_st *result)
+uint16_t drizzle_result_column_count(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -250,7 +250,7 @@ uint16_t drizzle_result_column_count(drizzle_result_st *result)
   return result->column_count;
 }
 
-uint64_t drizzle_result_row_count(drizzle_result_st *result)
+uint64_t drizzle_result_row_count(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -389,7 +389,7 @@ drizzle_return_t drizzle_result_buffer(drizzle_result_st *result)
   return DRIZZLE_RETURN_OK;
 }
 
-size_t drizzle_result_row_size(drizzle_result_st *result)
+size_t drizzle_result_row_size(const drizzle_result_st *result)
 {
   if (result == NULL)
   {

--- a/src/row.cc
+++ b/src/row.cc
@@ -176,7 +176,7 @@ void drizzle_row_free(drizzle_result_st *result, drizzle_row_t row)
 
 }
 
-size_t *drizzle_row_field_sizes(drizzle_result_st *result)
+size_t *drizzle_row_field_sizes(const drizzle_result_st *result)
 {
   if (result == NULL)
   {
@@ -237,7 +237,7 @@ void drizzle_row_seek(drizzle_result_st *result, uint64_t row)
     result->row_current= row;
 }
 
-drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row)
+drizzle_row_t drizzle_row_index(const drizzle_result_st *result, uint64_t row)
 {
   if (result == NULL)
   {
@@ -250,7 +250,7 @@ drizzle_row_t drizzle_row_index(drizzle_result_st *result, uint64_t row)
   return result->row_list[row];
 }
 
-uint64_t drizzle_row_current(drizzle_result_st *result)
+uint64_t drizzle_row_current(const drizzle_result_st *result)
 {
   if (result == NULL)
   {

--- a/src/statement.cc
+++ b/src/statement.cc
@@ -597,7 +597,7 @@ drizzle_return_t drizzle_stmt_close(drizzle_stmt_st *stmt)
   return ret;
 }
 
-uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt)
+uint16_t drizzle_stmt_column_count(const drizzle_stmt_st *stmt)
 {
   if ((stmt == NULL) || (stmt->prepare_result == NULL))
   {
@@ -607,7 +607,7 @@ uint16_t drizzle_stmt_column_count(drizzle_stmt_st *stmt)
   return stmt->prepare_result->column_count;
 }
 
-uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt)
+uint64_t drizzle_stmt_affected_rows(const drizzle_stmt_st *stmt)
 {
   if ((stmt == NULL) || (stmt->execute_result == NULL))
   {
@@ -617,7 +617,7 @@ uint64_t drizzle_stmt_affected_rows(drizzle_stmt_st *stmt)
   return stmt->execute_result->affected_rows;
 }
 
-uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt)
+uint64_t drizzle_stmt_insert_id(const drizzle_stmt_st *stmt)
 {
   if ((stmt == NULL) || (stmt->execute_result == NULL))
   {
@@ -627,7 +627,7 @@ uint64_t drizzle_stmt_insert_id(drizzle_stmt_st *stmt)
   return stmt->execute_result->insert_id;
 }
 
-uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt)
+uint16_t drizzle_stmt_param_count(const drizzle_stmt_st *stmt)
 {
   if (stmt == NULL)
   {
@@ -637,7 +637,7 @@ uint16_t drizzle_stmt_param_count(drizzle_stmt_st *stmt)
   return stmt->param_count;
 }
 
-uint64_t drizzle_stmt_row_count(drizzle_stmt_st *stmt)
+uint64_t drizzle_stmt_row_count(const drizzle_stmt_st *stmt)
 {
   if (stmt and stmt->execute_result)
   {

--- a/src/statement_param.cc
+++ b/src/statement_param.cc
@@ -178,7 +178,7 @@ drizzle_return_t drizzle_stmt_set_timestamp(drizzle_stmt_st *stmt, uint16_t para
   return drizzle_stmt_set_param(stmt, param_num, DRIZZLE_COLUMN_TYPE_TIMESTAMP, timestamp, 0, false);
 }
 
-bool drizzle_stmt_get_is_null_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+bool drizzle_stmt_get_is_null_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 {
   uint16_t column_number;
   if ((stmt == NULL) || (stmt->result_params == NULL))
@@ -194,7 +194,7 @@ bool drizzle_stmt_get_is_null_from_name(drizzle_stmt_st *stmt, const char *colum
   return drizzle_stmt_get_is_null(stmt, column_number, ret_ptr);
 }
 
-bool drizzle_stmt_get_is_null(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+bool drizzle_stmt_get_is_null(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 {
   if ((stmt == NULL) || (stmt->result_params == NULL) || (column_number >= stmt->execute_result->column_count))
   {
@@ -206,7 +206,7 @@ bool drizzle_stmt_get_is_null(drizzle_stmt_st *stmt, uint16_t column_number, dri
   return stmt->result_params[column_number].options.is_null;
 }
 
-bool drizzle_stmt_get_is_unsigned_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+bool drizzle_stmt_get_is_unsigned_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 {
   uint16_t column_number;
   if ((stmt == NULL) || (stmt->result_params == NULL))
@@ -222,7 +222,7 @@ bool drizzle_stmt_get_is_unsigned_from_name(drizzle_stmt_st *stmt, const char *c
   return drizzle_stmt_get_is_unsigned(stmt, column_number, ret_ptr);
 }
 
-bool drizzle_stmt_get_is_unsigned(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+bool drizzle_stmt_get_is_unsigned(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 {
   if ((stmt == NULL) || (stmt->result_params == NULL) || (column_number >= stmt->execute_result->column_count))
   {
@@ -234,7 +234,7 @@ bool drizzle_stmt_get_is_unsigned(drizzle_stmt_st *stmt, uint16_t column_number,
   return stmt->result_params[column_number].options.is_unsigned;
 }
 
-const char *drizzle_stmt_get_string_from_name(drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
+const char *drizzle_stmt_get_string_from_name(const drizzle_stmt_st *stmt, const char *column_name, size_t *len, drizzle_return_t *ret_ptr)
 {
   uint16_t column_number;
   if ((stmt == NULL) || (stmt->result_params == NULL))
@@ -250,7 +250,7 @@ const char *drizzle_stmt_get_string_from_name(drizzle_stmt_st *stmt, const char 
   return drizzle_stmt_get_string(stmt, column_number, len, ret_ptr);
 }
 
-const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr)
+const char *drizzle_stmt_get_string(const drizzle_stmt_st *stmt, uint16_t column_number, size_t *len, drizzle_return_t *ret_ptr)
 {
   char *val;
   drizzle_bind_st *param;
@@ -338,7 +338,8 @@ const char *drizzle_stmt_get_string(drizzle_stmt_st *stmt, uint16_t column_numbe
   return val;
 }
 
-uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+uint32_t drizzle_stmt_get_int_from_name(const drizzle_stmt_st *stmt,
+  const char *column_name, drizzle_return_t *ret_ptr)
 {
   uint16_t column_number;
   if ((stmt == NULL) || (stmt->result_params == NULL))
@@ -354,7 +355,7 @@ uint32_t drizzle_stmt_get_int_from_name(drizzle_stmt_st *stmt, const char *colum
   return drizzle_stmt_get_int(stmt, column_number, ret_ptr);
 }
 
-uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+uint32_t drizzle_stmt_get_int(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 {
   uint32_t val;
   drizzle_bind_st *param;
@@ -428,7 +429,7 @@ uint32_t drizzle_stmt_get_int(drizzle_stmt_st *stmt, uint16_t column_number, dri
   return val;
 }
 
-uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+uint64_t drizzle_stmt_get_bigint_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 {
   uint16_t column_number;
   if ((stmt == NULL) || (stmt->result_params == NULL))
@@ -444,7 +445,7 @@ uint64_t drizzle_stmt_get_bigint_from_name(drizzle_stmt_st *stmt, const char *co
   return drizzle_stmt_get_bigint(stmt, column_number, ret_ptr);
 }
 
-uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+uint64_t drizzle_stmt_get_bigint(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 {
   uint64_t val;
   drizzle_bind_st *param;
@@ -514,7 +515,7 @@ uint64_t drizzle_stmt_get_bigint(drizzle_stmt_st *stmt, uint16_t column_number, 
   return val;
 }
 
-double drizzle_stmt_get_double_from_name(drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
+double drizzle_stmt_get_double_from_name(const drizzle_stmt_st *stmt, const char *column_name, drizzle_return_t *ret_ptr)
 {
   uint16_t column_number;
   if ((stmt == NULL) || (stmt->result_params == NULL))
@@ -530,7 +531,7 @@ double drizzle_stmt_get_double_from_name(drizzle_stmt_st *stmt, const char *colu
   return drizzle_stmt_get_double(stmt, column_number, ret_ptr);
 }
 
-double drizzle_stmt_get_double(drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
+double drizzle_stmt_get_double(const drizzle_stmt_st *stmt, uint16_t column_number, drizzle_return_t *ret_ptr)
 {
   double val;
   drizzle_bind_st *param;

--- a/tests/unit/binlog.c
+++ b/tests/unit/binlog.c
@@ -49,8 +49,8 @@ void binlog_error(drizzle_return_t ret, drizzle_st *connection, void *context)
              drizzle_strerror(ret));
 }
 
-void binlog_event(drizzle_binlog_event_st *event, void *context);
-void binlog_event(drizzle_binlog_event_st *event, void *context)
+void binlog_event(const drizzle_binlog_event_st *event, void *context);
+void binlog_event(const drizzle_binlog_event_st *event, void *context)
 {
   (void)context;
   uint32_t timestamp;


### PR DESCRIPTION
Adds `const` qualifier to **POD** params which are not mutated by the function.

Since it is (possibly) a breaking change for clients it is added to the milestone for the next `major` release 