### PR TITLE
Add missing api funcs to rst docs

### DIFF
--- a/docs/api/query.rst
+++ b/docs/api/query.rst
@@ -46,16 +46,31 @@ Functions
    :param ret_ptr: A pointer to a :c:type:`drizzle_return_t` to store the return status into
    :returns: A newly allocated result object
 
-.. c:function:: ssize_t drizzle_escape_string(drizzle_st *con, char **to, const const char *from, const size_t from_size)
+.. c:function:: ssize_t drizzle_escape_str(drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern)
 
-   Escape a string for an SQL query. The ``to`` parameter is allocated by the
-   function and needs to be freed by the application when finished with.
+   Escape a string for an **SQL** query, optionally for pattern matching.
+
+   This function escapes the following characters::
+
+      '\0' (0x00), '\'' (0x27), '"' (0x22), '\b' (0x08), '\n' (0x0A),
+      '\r' (0x0D), '\t' (0x09), '\Z' (0x26), '\\' (0x5C).
+
+   In case **is_pattern** is set to :c:type:`true`, ``'%'`` ``(0x25)`` and ``'_'`` ``(0x5F)``
+   will be escaped as well.
+
+   The **to** parameter is allocated by the function and needs to be freed by
+   the application when finished with.
 
    :param con: a connection object
    :param to: the destination string
    :param from: the source string
    :param from_size: the length of the source string
-   :returns: the length of the 'to' string or -1 upon error due to empty parameters or overflow
+   :param is_pattern: whether to escape ``%`` and ``_``. If set to :c:type:`true`, they will be escaped, so the string can be used in a **LIKE** clause for example
+   :returns: the length of the **to** string or ``-1`` upon error due to empty parameters or overflow
+
+.. c:function:: ssize_t drizzle_escape_string(drizzle_st *con, char **to, const const char *from, const size_t from_size)
+
+   Function wrapper which calls :c:func:`drizzle_escape_str` with ``is_pattern=false``.
 
 .. c:function:: void drizzle_result_free(drizzle_result_st *result)
 

--- a/docs/api/query.rst
+++ b/docs/api/query.rst
@@ -455,3 +455,17 @@ Functions
    Frees field data for unbuffered row reads
 
    :param field: The field data to free
+
+.. c:function:: bool drizzle_success(drizzle_return_t ret)
+
+   Check if a drizzle function call succeeded
+
+   :param ret: result code
+   :returns: true on success, false otherwise
+
+.. c:function:: bool drizzle_failed(drizzle_return_t ret)
+
+   Check if a drizzle function call failed
+
+   :param ret: result code
+   :returns: true on fail, false otherwise

--- a/relnotes/query.api.feature.md
+++ b/relnotes/query.api.feature.md
@@ -1,0 +1,13 @@
+### Add missing documentation for API
+
+Some existing functions in the **query API** was not part of the **rst** documentation.
+
+`include/libdrizzle-redux/query.h`
+
+- `ssize_t drizzle_escape_str(drizzle_st *con, char **to, const char *from, const size_t from_size, bool is_pattern)`
+
+The **MySQL** manual lists 11 characters which should be escaped, including 2 which should only be escaped for a string used in a pattern-matching context (e.g. **LIKE** clause).
+
+The function `drizzle_escape_str` extends the capabilities of `drizzle_escape_string` by taking an extra parameter, `is_pattern`, specifying whether the string will be used in a pattern-matching context.
+
+The feature was part of [`v5.6.0`](https://github.com/sociomantic-tsunami/libdrizzle-redux/releases/tag/v5.6.0) but wasn't added to the documentation.

--- a/relnotes/query.api.feature.md
+++ b/relnotes/query.api.feature.md
@@ -11,3 +11,11 @@ The **MySQL** manual lists 11 characters which should be escaped, including 2 wh
 The function `drizzle_escape_str` extends the capabilities of `drizzle_escape_string` by taking an extra parameter, `is_pattern`, specifying whether the string will be used in a pattern-matching context.
 
 The feature was part of [`v5.6.0`](https://github.com/sociomantic-tsunami/libdrizzle-redux/releases/tag/v5.6.0) but wasn't added to the documentation.
+
+- `bool drizzle_success(drizzle_return_t ret)`
+
+Utility function to check if a `drizzle` function call succeeded
+
+- `bool drizzle_failed(drizzle_return_t ret)`
+
+Utility function to check if a `drizzle` function call failed


### PR DESCRIPTION
Adds documentation for existing functions in the **query API** which previously weren't part of the **rst** documentation. 