### PR TITLE
Fix llvm build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ jobs:
         CONFIGURE_ARGS="$CONFIGURE_ARGS --with-coverage-support=capture"
     - <<: *linux-build
       env:
-        DOCKER_CXX=clang++ DOCKER_CC=clang
+        DOCKER_CXX=clang++ DOCKER_CC=clang COMPILER_VERSION=4.0
     - <<: *linux-build
       env:
         DIST_NAME=centos DIST_VERSION=7 MAKE_TARGET=$MAKE_TARGET:rpm

--- a/docker/Dockerfile.ubuntu.xenial
+++ b/docker/Dockerfile.ubuntu.xenial
@@ -7,19 +7,6 @@ RUN export DEBIAN_FRONTEND=noninteractive
 # delete all the apt list files to speed up 'apt-get update' command
 RUN rm -rf /var/lib/apt/lists/*
 
-# add apt repository for clang compiler versions
-RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/apt/sources.list
-RUN echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial main" >> /etc/apt/sources.list
-
-# clang 5.0
-RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" >> /etc/apt/sources.list
-RUN echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" >> /etc/apt/sources.list
-
-# clang 6.0
-RUN echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" >> /etc/apt/sources.list
-RUN echo "deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" >> /etc/apt/sources.list
-
 # add apt repository for apt-fast
 RUN add-apt-repository ppa:apt-fast/stable
 


### PR DESCRIPTION
The deb package 'clang' refers to 8.0 in the manually added llvm repos, but 3.8 in the default xenial llvm apt repo.
This caused a conflict when trying to install the standard 'clang' package. 

Also, apt repos for clang 5.0 and 6.0 are already available as default in ubuntu xenial