### PR TITLE
[TRAVIS] Fix caching of deb package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,10 +122,12 @@ jobs:
     - <<: *deploy
       # Deploy deb packages to bintray. Doesn't build the packages but uses the
       # cache from the first stage.
+      # Note that the 'env' section must be identical to the build in stage 1
+      # which caches the generated deb package
       stage: deploy
       if: tag IS present AND tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+
       env:
-        COMPILER_VERSION=4.9 MAKE_TARGET=deb
+        COMPILER_VERSION=4.9 MAKE_TARGET=$MAKE_TARGET:deb:api-sanity-checker
       before_script: skip
       script:
         - beaver bintray upload -D $DIST_VERSION -N $CACHE_DIR/*.deb


### PR DESCRIPTION
The cached deb package was not available in the deploy
stage because the build configuration differed