### PR TITLE
Fix centos build

### DIFF
--- a/docker/Dockerfile.centos.7
+++ b/docker/Dockerfile.centos.7
@@ -3,7 +3,7 @@ FROM centos:7
 MAINTAINER andreas-bok-sociomantic <andreas.bok@sociomantic.com>
 
 # add repos for additional compiler toolsets
-RUN curl http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm -o /tmp/epel-release-7-11.noarch.rpm
+RUN curl http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-12.noarch.rpm -o /tmp/epel-release-7-12.noarch.rpm
 RUN rpm -Uvh /tmp/epel-release*rpm
 
 # install required packages


### PR DESCRIPTION
The clang package was updated and the previous version no longer exist
in the fedora project repository.