### PR TITLE
issue 334: fix: passwords of 32 characters were truncated to 31 characters

### DIFF
--- a/src/conn.cc
+++ b/src/conn.cc
@@ -513,7 +513,7 @@ void drizzle_set_auth(drizzle_st *con, const char *user,
   else
   {
     strncpy(con->password, password, DRIZZLE_MAX_PASSWORD_SIZE);
-    con->password[DRIZZLE_MAX_PASSWORD_SIZE - 1]= 0;
+    con->password[DRIZZLE_MAX_PASSWORD_SIZE]= 0;
   }
 }
 

--- a/src/structs.h
+++ b/src/structs.h
@@ -243,7 +243,7 @@ struct drizzle_st
   unsigned char *buffer;
   size_t buffer_allocation; /* total allocated size of 'buffer' */
   char db[DRIZZLE_MAX_DB_SIZE];
-  char password[DRIZZLE_MAX_PASSWORD_SIZE];
+  char password[DRIZZLE_MAX_PASSWORD_SIZE + 1];
   unsigned char scramble_buffer[DRIZZLE_MAX_SCRAMBLE_SIZE];
   char server_version[DRIZZLE_MAX_SERVER_VERSION_SIZE];
   char server_extra[DRIZZLE_MAX_SERVER_EXTRA_SIZE];


### PR DESCRIPTION
https://github.com/sociomantic-tsunami/libdrizzle-redux/issues/343