### PR TITLE
issue 287: SSL support

### DIFF
--- a/src/ssl.cc
+++ b/src/ssl.cc
@@ -46,7 +46,7 @@
 
 drizzle_return_t drizzle_set_ssl(drizzle_st *con, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher)
 {
-  con->ssl_context= SSL_CTX_new(SSLv23_client_method());
+  con->ssl_context= SSL_CTX_new(TLS_client_method());
 
   const long required_ssl_options = (SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
   long ssl_options =
@@ -95,8 +95,6 @@ drizzle_return_t drizzle_set_ssl(drizzle_st *con, const char *key, const char *c
       return DRIZZLE_RETURN_SSL_ERROR;
     }
   }
-
-  con->ssl= SSL_new((SSL_CTX*)con->ssl_context);
 
   return DRIZZLE_RETURN_OK;
 }


### PR DESCRIPTION
There are three classes of change

1. ````SSL_connect````, ````SSL_read````, and ````SSL_write```` use ````SSL_get_error```` in order to monitor the appropriate events on the I/O event loop.

2. The error you've noticed, namely that the BIO was not set, happened because ````SSL_set_fd```` was called only when the connection succeeded in ````drizzle_connect````. I've added it when the connection succeeds in ````drizzle_state_connecting````.

3. I've removed ````SSL_new```` from ````drizzle_set_ssl````. The reason is that ````drizzle_set_ssl```` is called only once, at setup, when we configure the certificates, while a ````SSL```` object is associated to a live network connection. Thus, the ````SSL_CTX```` is built only once, by ````drizzle_set_ssl````, while the ````SSL```` object is built whenever the ````connect```` system call succeeds and is freed in ````drizzle_close````.

Besides the normal operation, I've tested two scenarios:

1. I continuously pass SQL requests over the same connection while in another console I launch iptables commands to drop packets. The application detects the errors, calls ````drizzle_close```` and tries to reestablish the connection. SSL is correctly reestablished once I stop dropping the packets.

2. I continuously pass SQL requests over the same connection. Then I shutdown the MySQL server. The application reacts to it by calling ````drizzle_close````. I can see the Encrypted Alert that my client sends to the server before closing the socket.  SSL is correctly reestablished once I restart the server.

I am not sure that I handle the shutdowns (````SSL_shutdown````) correctly though.